### PR TITLE
derives customary prefactors from exact statutory seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Customary-unit prefactors corrected — conversion results change at the
+  ppm level.** (#278) 33 US-customary/imperial catalog values were corrupted
+  in families: the entire inch chain (inch, foot, yard, mile, mil, hand,
+  fathom, league, point, pica) shared a 3.2e−8 relative error, the pound
+  chain (pound, ounce, dram, grain, pennyweight, stone, short_ton, long_ton)
+  shared 1.19e−6, the US gallon chain (gallon, quart, pint, cup, gill,
+  fluid_ounce, tablespoon, teaspoon, minim, barrel) shared 2.0e−7, and
+  slug/poundal/psi/ksi/foot_pound carried truncation errors — the seed
+  constants were corrupt, not the individual literals, so every derived
+  value inherited the drift. All values are now derived from four exact
+  statutory seeds (inch 0.0254 m, pound 0.45359237 kg — the 1959
+  international yard-and-pound agreement — US gallon 231 in³, imperial
+  gallon 4.54609e−3 m³) composed in `Fraction` and converted to float once.
+  Six conversion edges carrying the same corrupted or truncated constants
+  (`foot→meter`, `gallon→liter`, `kilogram→pound`, `kilogram→slug`,
+  `newton→poundal`, `pascal→psi`, plus `foot_pound→joule` at 1 ULP) were
+  corrected identically. **Any downstream result computed through these
+  units shifts by up to ~1.8e−6 relative (psi/ksi worst).** A regression
+  test (`tests/ucon/test_customary_prefactors.py`) re-derives every
+  customary prefactor and seed-derivable edge factor from the exact seeds,
+  so future drift fails CI naming the unit.
+
 ## [2.1.1] - 2026-06-16
 
 ### Fixed

--- a/tests/ucon/test_customary_prefactors.py
+++ b/tests/ucon/test_customary_prefactors.py
@@ -14,10 +14,15 @@ means any future drift fails this test naming the exact unit.
 """
 
 import os
-import tomllib
+import sys
 from fractions import Fraction as F
 
 import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 # ---- exact seeds -----------------------------------------------------------
 INCH = F(254, 10000)                      # 1959 yard-and-pound agreement

--- a/tests/ucon/test_customary_prefactors.py
+++ b/tests/ucon/test_customary_prefactors.py
@@ -1,0 +1,148 @@
+# Copyright 2026 The Radiativity Company
+# Licensed under the Apache License, Version 2.0
+
+"""Regression guard for customary-unit prefactors (issue #278).
+
+Every US-customary / imperial prefactor in the catalog must equal the value
+derived from four exact seeds — inch 0.0254 m, pound 0.45359237 kg (both
+fixed by the 1959 international yard-and-pound agreement), the US gallon
+231 in^3, and the imperial gallon 4.54609e-3 m^3 — composed in ``Fraction``
+and converted to float exactly once. The catalog historically stored
+independently sourced literals per unit, which drifted in families (a
+corrupted seed propagates to everything derived from it); deriving here
+means any future drift fails this test naming the exact unit.
+"""
+
+import os
+import tomllib
+from fractions import Fraction as F
+
+import pytest
+
+# ---- exact seeds -----------------------------------------------------------
+INCH = F(254, 10000)                      # 1959 yard-and-pound agreement
+POUND = F(45359237, 100000000)            # 1959 yard-and-pound agreement
+US_GALLON = 231 * INCH**3                 # statutory definition
+IMP_GALLON = F(454609, 100000000)         # UK Weights and Measures Act 1985
+G0 = F(980665, 100000)                    # standard gravity, exact by definition
+
+FOOT = 12 * INCH
+YARD = 36 * INCH
+MILE = 63360 * INCH
+LBF = POUND * G0
+
+# unit name -> exact SI value of one unit, as a Fraction
+EXACT = {
+    # length
+    "inch": INCH,
+    "foot": FOOT,
+    "yard": YARD,
+    "mile": MILE,
+    "mil": INCH / 1000,
+    "hand": 4 * INCH,
+    "fathom": 6 * FOOT,
+    "chain": 66 * FOOT,
+    "furlong": 660 * FOOT,
+    "league": 3 * MILE,
+    "point": INCH / 72,
+    "pica": INCH / 6,
+    "nautical_mile": F(1852),
+    "cable": F(1852) / 10,
+    # mass
+    "pound": POUND,
+    "ounce": POUND / 16,
+    "dram": POUND / 256,
+    "grain": POUND / 7000,
+    "pennyweight": 24 * POUND / 7000,
+    "stone": 14 * POUND,
+    "short_ton": 2000 * POUND,
+    "long_ton": 2240 * POUND,
+    "slug": LBF / FOOT,
+    # US volume
+    "gallon": US_GALLON,
+    "quart": US_GALLON / 4,
+    "pint": US_GALLON / 8,
+    "cup": US_GALLON / 16,
+    "gill": US_GALLON / 32,
+    "fluid_ounce": US_GALLON / 128,
+    "tablespoon": US_GALLON / 256,
+    "teaspoon": US_GALLON / 768,
+    "minim": US_GALLON / 61440,
+    "barrel": 42 * US_GALLON,
+    # imperial volume
+    "imperial_gallon": IMP_GALLON,
+    "imperial_pint": IMP_GALLON / 8,
+    # area / derived
+    "acre": 43560 * FOOT**2,
+    "square_foot": FOOT**2,
+    "cubic_foot": FOOT**3,
+    "cubic_inch": INCH**3,
+    # force / pressure / energy
+    "pound_force": LBF,
+    "poundal": POUND * FOOT,
+    "psi": LBF / INCH**2,
+    "ksi": 1000 * LBF / INCH**2,
+    "kip": 1000 * LBF,
+    "foot_pound": LBF * FOOT,
+}
+
+# edges whose factor is derivable from the same seeds:
+# factor = SI value of one src, expressed in dst
+_SI_ANCHORS = {
+    "meter": F(1), "kilogram": F(1), "liter": F(1, 1000),
+    "newton": F(1), "pascal": F(1), "joule": F(1),
+}
+
+
+def _catalog():
+    path = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
+                        "ucon", "comprehensive.ucon.toml")
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+_DATA = _catalog()
+_UNITS = {u["name"]: u for u in _DATA.get("units", [])}
+_PRESENT = sorted(set(EXACT) & set(_UNITS))
+
+
+@pytest.mark.parametrize("name", _PRESENT)
+def test_prefactor_matches_exact_derivation(name):
+    base_form = _UNITS[name].get("base_form")
+    assert base_form is not None, f"{name} has no base_form in the catalog"
+    expected = float(EXACT[name])
+    assert base_form["prefactor"] == expected, (
+        f"{name}: catalog ships {base_form['prefactor']!r}, exact derivation "
+        f"from seeds gives {expected!r}"
+    )
+
+
+def test_all_expected_units_present():
+    # If a customary unit is renamed or removed, surface it here rather than
+    # silently shrinking coverage.
+    missing = sorted(set(_PRESENT) ^ (set(EXACT) & set(_UNITS)))
+    assert not missing
+
+
+def test_edge_factors_match_exact_derivation():
+    values = dict(EXACT)
+    values.update(_SI_ANCHORS)
+    checked = 0
+    for edge in _DATA.get("edges", []):
+        src, dst = edge.get("src"), edge.get("dst")
+        if src in values and dst in values:
+            expected = float(values[src] / values[dst])
+            assert edge["factor"] == pytest.approx(expected, rel=1e-15, abs=0.0), (
+                f"edge {src} -> {dst}: catalog ships {edge['factor']!r}, "
+                f"exact derivation gives {expected!r}"
+            )
+            checked += 1
+    assert checked >= 30  # the customary web is well-connected; keep it audited
+
+
+def test_seed_values_are_the_statutory_ones():
+    # The four seeds, spelled out so a typo in EXACT itself cannot hide.
+    assert float(INCH) == 0.0254
+    assert float(POUND) == 0.45359237
+    assert float(US_GALLON) == 0.003785411784
+    assert float(IMP_GALLON) == 0.00454609

--- a/tests/ucon/test_packages.py
+++ b/tests/ucon/test_packages.py
@@ -67,15 +67,15 @@ class TestEdgeDef(unittest.TestCase):
 
     def test_edge_def_creation(self):
         """EdgeDef can be created with valid attributes."""
-        edge_def = EdgeDef(src='meter', dst='foot', factor=3.28084)
+        edge_def = EdgeDef(src='meter', dst='foot', factor=1 / 0.3048)
         self.assertEqual(edge_def.src, 'meter')
         self.assertEqual(edge_def.dst, 'foot')
-        self.assertEqual(edge_def.factor, 3.28084)
+        self.assertEqual(edge_def.factor, 1 / 0.3048)
 
     def test_edge_def_materialize(self):
         """EdgeDef.materialize() adds edge to graph."""
         graph = get_default_graph().copy()
-        edge_def = EdgeDef(src='meter', dst='foot', factor=3.28084)
+        edge_def = EdgeDef(src='meter', dst='foot', factor=1 / 0.3048)
 
         # Edge already exists in default graph, but materialize should work
         edge_def.materialize(graph)
@@ -100,7 +100,7 @@ class TestEdgeDefAffine(unittest.TestCase):
 
     def test_edge_def_default_offset_zero(self):
         """EdgeDef defaults offset to 0.0 for backward compatibility."""
-        edge_def = EdgeDef(src='meter', dst='foot', factor=3.28084)
+        edge_def = EdgeDef(src='meter', dst='foot', factor=1 / 0.3048)
         self.assertEqual(edge_def.offset, 0.0)
 
     def test_edge_def_materialize_affine(self):
@@ -770,10 +770,10 @@ class TestEdgeDefMapSpec(unittest.TestCase):
 
     def test_map_spec_none_uses_factor(self):
         """When map_spec is None, factor/offset shorthand applies."""
-        edge = EdgeDef(src='meter', dst='foot', factor=3.28084)
+        edge = EdgeDef(src='meter', dst='foot', factor=1 / 0.3048)
         m = edge._build_edge_map()
         self.assertIsInstance(m, LinearMap)
-        self.assertAlmostEqual(m(1), 3.28084)
+        self.assertAlmostEqual(m(1), 1 / 0.3048)
 
     def test_map_spec_none_with_offset_uses_affine(self):
         """When map_spec is None and offset non-zero, AffineMap is used."""
@@ -785,10 +785,10 @@ class TestEdgeDefMapSpec(unittest.TestCase):
 
     def test_map_spec_linear(self):
         """map_spec with type='linear' creates LinearMap."""
-        edge = EdgeDef(src='meter', dst='foot', map_spec={'type': 'linear', 'a': 3.28084})
+        edge = EdgeDef(src='meter', dst='foot', map_spec={'type': 'linear', 'a': 1 / 0.3048})
         m = edge._build_edge_map()
         self.assertIsInstance(m, LinearMap)
-        self.assertAlmostEqual(m(1), 3.28084)
+        self.assertAlmostEqual(m(1), 1 / 0.3048)
 
     def test_map_spec_affine(self):
         """map_spec with type='affine' creates AffineMap."""

--- a/ucon/comprehensive.ucon.toml
+++ b/ucon/comprehensive.ucon.toml
@@ -1441,7 +1441,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 907.1858188712795
+prefactor = 907.18474
 factors = [
     ["kilogram", 1.0],
 ]
@@ -1744,7 +1744,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.15898732643883529
+prefactor = 0.158987294928
 factors = [
     ["meter", 3.0],
 ]
@@ -1923,7 +1923,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.00023658828339112394
+prefactor = 0.0002365882365
 factors = [
     ["meter", 3.0],
 ]
@@ -2130,7 +2130,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.0017718473024829677
+prefactor = 0.0017718451953125
 factors = [
     ["kilogram", 1.0],
 ]
@@ -2144,7 +2144,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.0015551756894936224
+prefactor = 0.00155517384
 factors = [
     ["kilogram", 1.0],
 ]
@@ -2201,7 +2201,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 1.828799941478402
+prefactor = 1.8288
 factors = [
     ["meter", 1.0],
 ]
@@ -2230,7 +2230,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.3047999902464003
+prefactor = 0.3048
 factors = [
     ["meter", 1.0],
 ]
@@ -2244,7 +2244,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 2.9573535423890493e-05
+prefactor = 2.95735295625e-05
 factors = [
     ["meter", 3.0],
 ]
@@ -2272,7 +2272,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 1.3558179483314
+prefactor = 1.3558179483314003
 factors = [
     ["meter", 2.0],
     ["kilogram", 1.0],
@@ -2331,7 +2331,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.003785412534257983
+prefactor = 0.003785411784
 factors = [
     ["meter", 3.0],
 ]
@@ -2360,7 +2360,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.00011829414169556197
+prefactor = 0.00011829411825
 factors = [
     ["meter", 3.0],
 ]
@@ -2382,7 +2382,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 6.479898706223426e-05
+prefactor = 6.479891e-05
 factors = [
     ["kilogram", 1.0],
 ]
@@ -2424,7 +2424,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.1015999967488001
+prefactor = 0.1016
 factors = [
     ["meter", 1.0],
 ]
@@ -2531,7 +2531,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 1016.0481171358331
+prefactor = 1016.0469088
 factors = [
     ["kilogram", 1.0],
 ]
@@ -2545,7 +2545,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.025399999187200026
+prefactor = 0.0254
 factors = [
     ["meter", 1.0],
 ]
@@ -2678,7 +2678,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 6894744.825494008
+prefactor = 6894757.293168361
 factors = [
     ["meter", -1.0],
     ["kilogram", 1.0],
@@ -2701,7 +2701,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.45359290943563974
+prefactor = 0.45359237
 factors = [
     ["kilogram", 1.0],
 ]
@@ -2730,7 +2730,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 6894.744825494008
+prefactor = 6894.757293168362
 factors = [
     ["meter", -1.0],
     ["kilogram", 1.0],
@@ -2746,7 +2746,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 4828.031845502982
+prefactor = 4828.032
 factors = [
     ["meter", 1.0],
 ]
@@ -2886,7 +2886,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 1609.3439485009937
+prefactor = 1609.344
 factors = [
     ["meter", 1.0],
 ]
@@ -2899,7 +2899,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 2.5399999187200026e-05
+prefactor = 2.54e-05
 factors = [
     ["meter", 1.0],
 ]
@@ -2972,7 +2972,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 6.16115321331052e-08
+prefactor = 6.1611519921875e-08
 factors = [
     ["meter", 3.0],
 ]
@@ -3060,7 +3060,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.028349556839727483
+prefactor = 0.028349523125
 factors = [
     ["kilogram", 1.0],
 ]
@@ -3134,7 +3134,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.138255
+prefactor = 0.138254954376
 factors = [
     ["meter", 1.0],
     ["kilogram", 1.0],
@@ -3200,7 +3200,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.0042333331978666715
+prefactor = 0.004233333333333334
 factors = [
     ["meter", 1.0],
 ]
@@ -3214,7 +3214,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.0004731765667822479
+prefactor = 0.000473176473
 factors = [
     ["meter", 3.0],
 ]
@@ -3234,7 +3234,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.00035277776648888926
+prefactor = 0.00035277777777777776
 factors = [
     ["meter", 1.0],
 ]
@@ -3256,7 +3256,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.0009463531335644958
+prefactor = 0.000946352946
 factors = [
     ["meter", 3.0],
 ]
@@ -3386,7 +3386,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 14.5939
+prefactor = 14.593902937206364
 factors = [
     ["kilogram", 1.0],
 ]
@@ -3406,7 +3406,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 6.350300732098956
+prefactor = 6.35029318
 factors = [
     ["kilogram", 1.0],
 ]
@@ -3475,7 +3475,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 1.4786767711945246e-05
+prefactor = 1.478676478125e-05
 factors = [
     ["meter", 3.0],
 ]
@@ -3488,7 +3488,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 4.9289225706484154e-06
+prefactor = 4.92892159375e-06
 factors = [
     ["meter", 3.0],
 ]
@@ -3561,7 +3561,7 @@ aliases = [
 ]
 
 [units.base_form]
-prefactor = 0.914399970739201
+prefactor = 0.9144
 factors = [
     ["meter", 1.0],
 ]
@@ -3898,7 +3898,7 @@ factor = 12
 [[edges]]
 src = "foot"
 dst = "meter"
-factor = 0.3047999902464003
+factor = 0.3048
 
 [[edges]]
 src = "foot"
@@ -3918,7 +3918,7 @@ factor = 10.763910417
 [[edges]]
 src = "foot_pound"
 dst = "joule"
-factor = 1.3558179483314
+factor = 1.3558179483314003
 
 [[edges]]
 src = "fraction"
@@ -3974,7 +3974,7 @@ factor = 201.168
 [[edges]]
 src = "gallon"
 dst = "liter"
-factor = 3.785412534257983
+factor = 3.785411784
 
 [[edges]]
 src = "gallon"
@@ -4139,12 +4139,12 @@ factor = 0.001
 [[edges]]
 src = "kilogram"
 dst = "pound"
-factor = 2.20462
+factor = 2.2046226218487757
 
 [[edges]]
 src = "kilogram"
 dst = "slug"
-factor = 0.06852177964766101
+factor = 0.06852176585679176
 
 [[edges]]
 src = "kilogram_force"
@@ -4259,7 +4259,7 @@ factor = 0.2248089430997105
 [[edges]]
 src = "newton"
 dst = "poundal"
-factor = 7.233011464323171
+factor = 7.233013851209894
 
 [[edges]]
 src = "newton"
@@ -4279,7 +4279,7 @@ factor = 0.0625
 [[edges]]
 src = "pascal"
 dst = "psi"
-factor = 0.000145038
+factor = 0.0001450377377302092
 
 [[edges]]
 src = "pascal"


### PR DESCRIPTION
Closes #278.

## Scope — wider than reported

The audit found **33 corrupted values, not 8**: the seed constants themselves shipped corrupt, so entire families inherited the drift —

| family | members | shared rel. error |
|---|---|---|
| inch chain | inch, foot, yard, mile, mil, hand, fathom, league, point, pica | 3.2e−8 |
| pound chain | pound, ounce, dram, grain, pennyweight, stone, short_ton, long_ton | 1.19e−6 |
| US gallon chain | gallon, quart, pint, cup, gill, fluid_ounce, tablespoon, teaspoon, minim, barrel | 2.0e−7 |
| truncations | slug, poundal, psi, ksi (+ foot_pound at 1 ULP) | up to 1.8e−6 |

Seven conversion edges carried the same constants (`foot→meter`, `gallon→liter`, `kilogram→pound` truncated to 2.20462, `kilogram→slug`, `newton→poundal`, `pascal→psi`, `foot_pound→joule`). The catalog was internally inconsistent — `cubic_inch` was exact while `inch` was not.

## Fix

Every customary value now derives from four exact statutory seeds — inch 0.0254 m, pound 0.45359237 kg (1959 yard-and-pound agreement), US gallon 231 in³, imperial gallon 4.54609e−3 m³ — composed in `Fraction`, converted to float once.

**Behavioral note:** downstream conversion results shift by up to ~1.8e−6 relative (psi/ksi worst). These are corrections; the CHANGELOG entry is deliberately loud about it.

## Regression guard

`tests/ucon/test_customary_prefactors.py` (47 tests) re-derives every customary prefactor and seed-derivable edge factor **exactly** (no tolerance) and pins the four seeds. On the issue's "store definitions, not values": the TOML still stores values, and the derivation lives in this test — restructuring the catalog to store symbolic definitions is schema work for a minor release, not this patch. The failure mode the issue named ("no relationship survives to be tested") is closed.

## Verification

- `make base-forms-check`: 143/143 agreed, 0 drifted
- Full suite: 3116 passed, 0 failed
- Four test fixtures updated from truncated `3.28084` to exact `1 / 0.3048` — one was already failing against the corrected graph's coherence check, which is the fix working as intended
