### PR TITLE
resolves constant symbols in package edge factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Edge factors may now reference declared constants.** (#279)
+  `_parse_factor` resolves symbols in factor/offset expressions against the
+  package's own `[[constants]]` section (symbols and aliases, including
+  NFKC-normalized spellings — Python's tokenizer folds `gₙ` to `gn`), so
+  `factor = "gₙ"` and `factor = "1 / gₙ"` evaluate instead of raising
+  `PackageLoadError`. This unblocks every constant-bearing package —
+  including ucon's own bundled `comprehensive.ucon.toml`, which previously
+  failed to `load_package` on its first constant-licensed edge. A symbol
+  that is not a valid Python identifier (e.g. `μ₀`) may be used as the
+  entire factor string; unresolvable symbols still refuse, now naming the
+  available symbols.
+
+## [2.1.2] - 2026-09-09
+
+### Fixed
+
 - **Customary-unit prefactors corrected — conversion results change at the
   ppm level.** (#278) 33 US-customary/imperial catalog values were corrupted
   in families: the entire inch chain (inch, foot, yard, mile, mil, hand,
@@ -2587,6 +2603,7 @@ Deprecated surfaces are scheduled for removal in v2.0.
 - Initial commit
 
 <!-- Links -->
+[2.1.2]: https://github.com/withtwoemms/ucon/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/withtwoemms/ucon/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/withtwoemms/ucon/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/withtwoemms/ucon/compare/2.0.0...2.0.1

--- a/tests/ucon/test_packages.py
+++ b/tests/ucon/test_packages.py
@@ -446,6 +446,109 @@ class TestParseFactorEdgeCases(unittest.TestCase):
             _parse_factor("x * y")
 
 
+class TestConstantFactors(unittest.TestCase):
+    """Edge factors may reference declared [[constants]] symbols (#279)."""
+
+    CONSTANTS = {
+        'gₙ': 9.80665, 'gn': 9.80665,   # declared + NFKC spelling
+        'c': 299792458.0,
+        'g0': 9.80665,                   # alias
+        'μ₀': 1.25663706127e-06,         # not a valid Python identifier
+    }
+
+    def test_bare_symbol(self):
+        """A factor that is exactly a declared symbol resolves."""
+        from ucon.packages import _parse_factor
+        self.assertEqual(_parse_factor("gₙ", self.CONSTANTS), 9.80665)
+
+    def test_symbol_in_expression(self):
+        """Symbols participate in * and / expressions."""
+        from ucon.packages import _parse_factor
+        self.assertAlmostEqual(_parse_factor("1 / gₙ", self.CONSTANTS), 1 / 9.80665)
+        self.assertEqual(_parse_factor("c * 2", self.CONSTANTS), 2 * 299792458.0)
+
+    def test_nfkc_normalization(self):
+        """gₙ inside an expression reaches the AST as 'gn' and still resolves."""
+        from ucon.packages import _parse_factor
+        self.assertEqual(_parse_factor("gₙ * 1000", self.CONSTANTS), 9806.65)
+
+    def test_alias_resolves(self):
+        """Constant aliases resolve like symbols."""
+        from ucon.packages import _parse_factor
+        self.assertEqual(_parse_factor("g0", self.CONSTANTS), 9.80665)
+
+    def test_non_identifier_symbol_bare_only(self):
+        """μ₀ works as the entire factor string but not inside expressions."""
+        from ucon.packages import _parse_factor
+        self.assertEqual(_parse_factor("μ₀", self.CONSTANTS), 1.25663706127e-06)
+        with self.assertRaises(PackageLoadError) as ctx:
+            _parse_factor("2 * μ₀", self.CONSTANTS)
+        self.assertIn('entire factor string', str(ctx.exception))
+
+    def test_unknown_symbol_names_available(self):
+        """An unresolvable symbol errors, listing declared symbols."""
+        from ucon.packages import _parse_factor
+        with self.assertRaises(PackageLoadError) as ctx:
+            _parse_factor("k_B * 2", self.CONSTANTS)
+        self.assertIn('k_B', str(ctx.exception))
+        self.assertIn('gn', str(ctx.exception))
+
+    def test_no_constants_still_raises(self):
+        """Without a constants mapping, symbols raise as before."""
+        from ucon.packages import _parse_factor
+        with self.assertRaises(PackageLoadError):
+            _parse_factor("gₙ")
+
+    def test_load_package_resolves_constant_factor(self):
+        """End-to-end: [[constants]] symbol used in an edge factor and offset."""
+        toml_content = '''
+[package]
+name = "const_factor_test"
+version = "1.0.0"
+
+[[units]]
+name = "test_gee"
+dimension = "acceleration"
+aliases = ["tg"]
+
+[[constants]]
+symbol = "gₙ"
+name = "standard gravity"
+value = 9.80665
+unit = "m/s^2"
+category = "exact"
+aliases = ["g0"]
+
+[[edges]]
+src = "test_gee"
+dst = "meter_per_second_squared"
+factor = "gₙ"
+'''
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.toml', delete=False
+        ) as f:
+            f.write(toml_content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            pkg = load_package(path)
+            self.assertEqual(pkg.edges[0].factor, 9.80665)
+        finally:
+            path.unlink()
+
+    def test_bundled_catalog_loads(self):
+        """Acceptance: ucon's own comprehensive.ucon.toml loads (#279)."""
+        import os
+        import ucon as ucon_pkg
+        path = os.path.join(
+            os.path.dirname(ucon_pkg.__file__), 'comprehensive.ucon.toml')
+        pkg = load_package(path)
+        self.assertGreater(len(pkg.constants), 0)
+        kgf = [e for e in pkg.edges if e.src == 'kilogram_force']
+        self.assertEqual(kgf[0].factor, 9.80665)
+
+
 class TestEdgeDefUnknownDst(unittest.TestCase):
     """Test EdgeDef.materialize() with unknown destination unit."""
 

--- a/ucon/packages.py
+++ b/ucon/packages.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING
 
 import ast
 import operator
+import unicodedata
 
 from ucon.constants import Constant
 from ucon.core import Unit, UnknownUnitError
@@ -64,18 +65,28 @@ if TYPE_CHECKING:
     from ucon.graph import ConversionGraph
 
 
-def _parse_factor(value) -> float:
+def _parse_factor(value, constants: 'dict[str, float] | None' = None) -> float:
     """Parse a factor value from TOML.
 
-    Accepts either a numeric value (int/float) or an arithmetic expression
-    string containing integers, ``/``, and ``*``.  This allows TOML files
-    to express exact ratios like ``"1852 / 3600"`` instead of truncated
-    decimals like ``0.514444``.
+    Accepts a numeric value (int/float) or an arithmetic expression string
+    containing numeric literals, declared constant symbols, ``/``, and
+    ``*``.  This allows TOML files to express exact ratios like
+    ``"1852 / 3600"`` instead of truncated decimals like ``0.514444``, and
+    physically-licensed factors like ``"gₙ"`` or ``"1 / gₙ"`` instead of
+    hand-copied constant values.
 
     Parameters
     ----------
     value : int, float, or str
         The factor as a number or arithmetic expression.
+    constants : dict[str, float], optional
+        Declared constant symbols (and aliases) available to the
+        expression, as produced by the package's ``[[constants]]``
+        section.  Keys must include NFKC-normalized spellings: Python's
+        tokenizer normalizes identifiers, so ``gₙ`` reaches the AST as
+        ``gn``.  A symbol that is not a valid Python identifier (e.g.
+        ``μ₀``) can still be used as the entire factor string, but not
+        inside an arithmetic expression.
 
     Returns
     -------
@@ -85,12 +96,21 @@ def _parse_factor(value) -> float:
     Raises
     ------
     PackageLoadError
-        If the string is not a valid arithmetic expression.
+        If the string is not a valid arithmetic expression, or references
+        a symbol not present in *constants*.
     """
     if isinstance(value, (int, float)):
         return float(value)
     if not isinstance(value, str):
         raise PackageLoadError(f"factor must be a number or expression string, got {type(value).__name__}")
+
+    constants = constants or {}
+    stripped = value.strip()
+
+    # Bare-symbol fast path: serves symbols that are not valid Python
+    # identifiers (μ₀ has a subscript digit, which the tokenizer rejects).
+    if stripped in constants:
+        return float(constants[stripped])
 
     _OPS = {
         ast.Mult: operator.mul,
@@ -105,20 +125,32 @@ def _parse_factor(value) -> float:
             return float(node.value)
         if hasattr(ast, 'Num') and isinstance(node, ast.Num):  # Python 3.7 compat
             return float(node.n)
+        if isinstance(node, ast.Name):
+            if node.id in constants:
+                return float(constants[node.id])
+            available = ', '.join(sorted(constants)) or '(none declared)'
+            raise PackageLoadError(
+                f"Unknown constant symbol {node.id!r} in factor: {value!r}. "
+                f"Symbols available from [[constants]]: {available}"
+            )
         if isinstance(node, ast.UnaryOp) and type(node.op) in _OPS:
             return _OPS[type(node.op)](_eval_node(node.operand))
         if isinstance(node, ast.BinOp) and type(node.op) in _OPS:
             return _OPS[type(node.op)](_eval_node(node.left), _eval_node(node.right))
         raise PackageLoadError(
             f"Unsupported expression in factor: {value!r}. "
-            "Only numeric literals with * and / are allowed."
+            "Only numeric literals, declared constant symbols, * and / are allowed."
         )
 
     try:
-        tree = ast.parse(value.strip(), mode='eval')
+        tree = ast.parse(stripped, mode='eval')
         return _eval_node(tree)
     except SyntaxError:
-        raise PackageLoadError(f"Invalid factor expression: {value!r}")
+        raise PackageLoadError(
+            f"Invalid factor expression: {value!r}. "
+            "Note: a constant symbol that is not a valid identifier "
+            "(e.g. μ₀) may only be used as the entire factor string."
+        )
 
 
 def _get_dimension_map() -> dict[str, Dimension]:
@@ -552,6 +584,17 @@ def load_package(path: str | Path) -> UnitPackage:
         for u in data.get("units", [])
     )
 
+    # Constant symbols available to edge-factor expressions.  Keyed by the
+    # declared symbol, each alias, and their NFKC normalizations — Python's
+    # tokenizer NFKC-normalizes identifiers, so "gₙ" reaches the AST as
+    # "gn" and both spellings must resolve.
+    constant_values: dict[str, float] = {}
+    for c in data.get("constants", []):
+        val = float(c["value"])
+        for key in (c["symbol"], *c.get("aliases", ())):
+            constant_values.setdefault(key, val)
+            constant_values.setdefault(unicodedata.normalize("NFKC", key), val)
+
     # Parse edges
     # Supports two forms:
     #   factor/offset shorthand: { src, dst, factor, offset? }
@@ -567,8 +610,8 @@ def load_package(path: str | Path) -> UnitPackage:
         return EdgeDef(
             src=e["src"],
             dst=e["dst"],
-            factor=_parse_factor(e["factor"]),
-            offset=_parse_factor(e.get("offset", 0.0)),
+            factor=_parse_factor(e["factor"], constant_values),
+            offset=_parse_factor(e.get("offset", 0.0), constant_values),
             rel_uncertainty=float(e.get("rel_uncertainty", 0.0)),
         )
 


### PR DESCRIPTION
Closes #279.

## Fix

`_parse_factor` gains an optional constants mapping, built in `load_package` from the package's own `[[constants]]` section (symbols **and aliases**), and consulted for `ast.Name` nodes during expression evaluation. `factor = "gₙ"` and `factor = "1 / gₙ"` now evaluate; unresolvable symbols still refuse, naming the available symbols. `offset` expressions get the same treatment.

Two Unicode wrinkles surfaced and are handled + tested:

- **NFKC normalization**: Python's tokenizer folds identifiers, so `gₙ` reaches the AST as `gn`. The mapping is keyed by declared spellings *and* their NFKC normalizations.
- **Non-identifier symbols**: `μ₀` (subscript digit) is a Python `SyntaxError` inside expressions. A bare-string fast path serves it as the entire factor string; using it inside an expression errors with a message saying exactly that.

## Scope note

Resolution is against the package's **own** `[[constants]]` only. `requires`-imported constants aren't resolvable at `load_package` time (required packages aren't loaded there); if cross-package constant references become a real need, that belongs with the 2.2.0 package-composition work (#282's neighborhood), not this patch.

## Acceptance

The bundled `comprehensive.ucon.toml` — previously failing on its first constant-licensed edge — now loads: 234 units, 148 edges, 26 constants; `kilogram_force → newton` carries 9.80665, `meter_per_second_squared → standard_gravity` carries 1/9.80665.

## Verification

- 9 new tests (`TestConstantFactors`), including the bundled-catalog acceptance test
- Full suite: 3078 passed, 0 failed; all prior `_parse_factor` edge-case tests pass unchanged (no constants → old refusal behavior preserved)
