### PR TITLE
resolves paths through composite edge endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Paths through composite edge endpoints now resolve.** (#280) A package
+  binding a unit to a composite SI expression (edge `dst = "meter^3"`)
+  created a node invisible to unit-level path search: `us_gallon →
+  meter^3` converted, `meter^3 → liter` converted, but `us_gallon → liter`
+  raised `ConversionNotFound`. Path search now unifies a product node with
+  any registered unit sharing its base-form signature (same factors; the
+  prefactor ratio becomes the map, e.g. `meter³ ↔ liter` at ×1000), and
+  unit-level lookups fall back into product space on failure. Only
+  previously-failing lookups change; `__eq__` across the
+  `Unit`/`UnitProduct` boundary is deliberately untouched (full identity
+  unification is scheduled for the next major).
+
+## [2.1.3] - 2026-09-09
+
+### Fixed
+
 - **Edge factors may now reference declared constants.** (#279)
   `_parse_factor` resolves symbols in factor/offset expressions against the
   package's own `[[constants]]` section (symbols and aliases, including
@@ -2603,6 +2619,7 @@ Deprecated surfaces are scheduled for removal in v2.0.
 - Initial commit
 
 <!-- Links -->
+[2.1.3]: https://github.com/withtwoemms/ucon/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/withtwoemms/ucon/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/withtwoemms/ucon/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/withtwoemms/ucon/compare/2.0.1...2.1.0

--- a/tests/ucon/conversion/test_composite_endpoints.py
+++ b/tests/ucon/conversion/test_composite_endpoints.py
@@ -1,0 +1,106 @@
+# © 2026 The Radiativity Company
+# Licensed under the Apache License, Version 2.0
+# See the LICENSE file for details.
+
+"""Path resolution through composite (UnitProduct) edge endpoints (#280).
+
+A package may bind a unit to a composite SI expression (edge dst =
+"meter^3"). Such product edges were invisible to unit-level BFS, so an
+edge to ``meter^3`` was unreachable from ``liter`` even though the direct
+``meter^3 → liter`` conversion succeeded: one hop worked, two hops through
+the composite node did not. The fix unifies a product node with any
+registered unit sharing its base-form signature (same factors, prefactor
+ratio as the map), and falls back from unit-level BFS into product space.
+
+Narrow by design: only ``ConversionNotFound`` outcomes may become
+successes. ``__eq__`` across the Unit/UnitProduct boundary is untouched
+(full identity unification is scheduled for the next major).
+"""
+
+import unittest
+
+from ucon import Number, units
+from ucon.core import Unit, UnitProduct
+from ucon.dimension import Dimension
+from ucon.graph import (
+    ConversionNotFound,
+    get_default_graph,
+    using_conversion_graph,
+)
+from ucon.maps import LinearMap
+from ucon.resolver import parse_unit
+
+US_GALLON_M3 = 0.003785411784  # 231 in³, exact
+
+
+class TestCompositeEndpointPaths(unittest.TestCase):
+    """The issue-#280 reproduction: an edge bound to meter^3."""
+
+    def setUp(self):
+        self.graph = get_default_graph().copy()
+        self.gallon = Unit(
+            name='us_gallon', dimension=Dimension.volume, aliases=('us_gal',))
+        self.graph.register_unit(self.gallon)
+        self.m3 = parse_unit('meter^3')
+        self.graph.add_edge(
+            src=self.gallon, dst=self.m3, map=LinearMap(US_GALLON_M3))
+
+    def test_edge_to_composite_still_converts_directly(self):
+        with using_conversion_graph(self.graph):
+            result = Number(1, self.gallon).to(self.m3)
+        self.assertAlmostEqual(result.quantity, US_GALLON_M3, places=15)
+
+    def test_path_through_composite_reaches_named_unit(self):
+        """us_gallon → meter^3 → liter: the previously-failing two-hop path."""
+        with using_conversion_graph(self.graph):
+            result = Number(1, self.gallon).to(units.liter)
+        self.assertAlmostEqual(result.quantity, US_GALLON_M3 * 1000, places=12)
+
+    def test_inverse_path_from_named_unit(self):
+        with using_conversion_graph(self.graph):
+            result = Number(US_GALLON_M3 * 1000, units.liter).to(self.gallon)
+        self.assertAlmostEqual(result.quantity, 1.0, places=12)
+
+    def test_direct_product_conversion_unchanged(self):
+        """Regression: the one-hop base-form path that always worked."""
+        with using_conversion_graph(self.graph):
+            result = Number(1, self.m3).to(units.liter)
+        self.assertAlmostEqual(result.quantity, 1000.0, places=12)
+
+    def test_equality_untouched(self):
+        """The narrow fix does not change __eq__ across the type boundary."""
+        self.assertFalse(self.m3 == units.liter)
+        self.assertTrue(self.m3.dimension == units.liter.dimension)
+
+    def test_unreachable_pair_still_refuses(self):
+        """Only failures become successes: a genuinely unconnected unit
+        still raises ConversionNotFound."""
+        orphan = Unit(
+            name='orphan_vol', dimension=Dimension.volume, aliases=('ov',))
+        self.graph.register_unit(orphan)
+        with using_conversion_graph(self.graph):
+            with self.assertRaises(ConversionNotFound):
+                Number(1, orphan).to(units.liter)
+
+
+class TestBaseFormSiblings(unittest.TestCase):
+    """The unification primitive: product ↔ same-signature unit."""
+
+    def test_meter_cubed_sibling_is_liter(self):
+        graph = get_default_graph().copy()
+        m3 = parse_unit('meter^3')
+        siblings = dict(graph._base_form_siblings(m3))
+        self.assertIn(units.liter, siblings)
+        self.assertAlmostEqual(siblings[units.liter](1.0), 1000.0, places=9)
+
+    def test_product_from_key_round_trips(self):
+        graph = get_default_graph().copy()
+        m3 = parse_unit('meter^3')
+        key = graph._product_key(m3)
+        rebuilt = graph._product_from_key(key)
+        self.assertIsNotNone(rebuilt)
+        self.assertEqual(graph._product_key(rebuilt), key)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ucon/conversion/test_composite_endpoints.py
+++ b/tests/ucon/conversion/test_composite_endpoints.py
@@ -82,6 +82,97 @@ class TestCompositeEndpointPaths(unittest.TestCase):
             with self.assertRaises(ConversionNotFound):
                 Number(1, orphan).to(units.liter)
 
+    def test_refusal_preserves_unit_level_message(self):
+        """When both searches fail, the original unit-level error is
+        re-raised — not the product-space one."""
+        orphan = Unit(
+            name='orphan_vol2', dimension=Dimension.volume, aliases=('ov2',))
+        self.graph.register_unit(orphan)
+        with using_conversion_graph(self.graph):
+            with self.assertRaises(ConversionNotFound) as ctx:
+                Number(1, orphan).to(units.liter)
+        self.assertIn('No path from', str(ctx.exception))
+        self.assertNotIn('No product path', str(ctx.exception))
+
+    def test_dimension_mismatch_not_swallowed_by_fallback(self):
+        """The fallback fires only on ConversionNotFound; dimension errors
+        propagate untouched."""
+        from ucon.graph import DimensionMismatch
+        with using_conversion_graph(self.graph):
+            with self.assertRaises(DimensionMismatch):
+                self.graph.convert(src=self.gallon, dst=units.kilogram)
+
+    def test_fallback_result_is_cached(self):
+        """A conversion found via the product-space fallback is cached:
+        the second lookup returns the same Map object."""
+        with using_conversion_graph(self.graph):
+            first = self.graph.convert(src=self.gallon, dst=units.liter)
+            second = self.graph.convert(src=self.gallon, dst=units.liter)
+        self.assertIs(first, second)
+
+    def test_three_hop_path_mixing_all_edge_kinds(self):
+        """barrel → us_gallon (unit edge) → meter³ (product edge) → liter
+        (base-form sibling): the search composes all three link kinds."""
+        barrel = Unit(
+            name='oil_barrel', dimension=Dimension.volume, aliases=('bbl',))
+        self.graph.register_unit(barrel)
+        self.graph.add_edge(src=barrel, dst=self.gallon, map=LinearMap(42))
+        with using_conversion_graph(self.graph):
+            result = Number(1, barrel).to(units.liter)
+        self.assertAlmostEqual(
+            result.quantity, 42 * US_GALLON_M3 * 1000, places=9)
+
+    def test_search_continues_past_non_target_siblings(self):
+        """The target sits one unit-edge beyond a sibling, so every sibling
+        of meter³ is a non-terminal expansion the search must queue and
+        continue through: us_gallon → meter³ → sibling → unit edge → dst."""
+        beyond = Unit(
+            name='beyond_liter', dimension=Dimension.volume, aliases=('byl',))
+        self.graph.register_unit(beyond)
+        self.graph.add_edge(src=units.liter, dst=beyond, map=LinearMap(2.0))
+        with using_conversion_graph(self.graph):
+            result = Number(1, self.gallon).to(beyond)
+        self.assertAlmostEqual(
+            result.quantity, US_GALLON_M3 * 1000 * 2.0, places=9)
+
+    def test_sibling_link_serves_composites_without_product_edges(self):
+        """meter³ happens to have a catalog product edge to liter, so the
+        original reproduction resolves through product edges alone. A
+        composite with NO catalog product edge — kilometer³ — is reachable
+        only through the base-form sibling link; this pins the sibling
+        mechanism end-to-end."""
+        km3 = parse_unit('kilometer^3')
+        vast = Unit(
+            name='vast_vol', dimension=Dimension.volume, aliases=('vv',))
+        self.graph.register_unit(vast)
+        self.graph.add_edge(src=vast, dst=km3, map=LinearMap(0.5))
+        with using_conversion_graph(self.graph):
+            result = Number(1, vast).to(units.liter)
+        # 0.5 km³ = 0.5e9 m³ = 0.5e12 L
+        self.assertAlmostEqual(result.quantity / 0.5e12, 1.0, places=9)
+
+    def test_bfs_direct_product_edge_short_circuit(self):
+        """_bfs_product_path returns a direct product edge without search."""
+        direct = self.graph._bfs_product_path(
+            src=UnitProduct.from_unit(self.gallon), dst=self.m3)
+        self.assertAlmostEqual(direct(1.0), US_GALLON_M3, places=15)
+
+    def test_unreconstructable_product_node_degrades_gracefully(self):
+        """A product edge whose endpoint contains an unregistered unit
+        yields a node the search cannot expand further; the search skips
+        it and refuses rather than crashing."""
+        hidden = Unit(
+            name='hidden_vol', dimension=Dimension.volume, aliases=('hv',))
+        # deliberately NOT registered in the name registry
+        start = Unit(
+            name='start_vol', dimension=Dimension.volume, aliases=('sv',))
+        self.graph.register_unit(start)
+        self.graph.add_edge(
+            src=start, dst=UnitProduct.from_unit(hidden), map=LinearMap(3.0))
+        with using_conversion_graph(self.graph):
+            with self.assertRaises(ConversionNotFound):
+                Number(1, start).to(units.liter)
+
 
 class TestBaseFormSiblings(unittest.TestCase):
     """The unification primitive: product ↔ same-signature unit."""
@@ -100,6 +191,47 @@ class TestBaseFormSiblings(unittest.TestCase):
         rebuilt = graph._product_from_key(key)
         self.assertIsNotNone(rebuilt)
         self.assertEqual(graph._product_key(rebuilt), key)
+
+    def test_product_from_key_unknown_unit_returns_none(self):
+        """A key naming a unit absent from the registry cannot be
+        reconstructed — the search degrades gracefully instead of raising."""
+        graph = get_default_graph().copy()
+        m3 = parse_unit('meter^3')
+        (name, dim, scale, exp), = graph._product_key(m3)
+        fake_key = (('not_a_registered_unit', dim, scale, exp),)
+        self.assertIsNone(graph._product_from_key(fake_key))
+
+    def test_siblings_of_undecomposable_product_is_empty(self):
+        """A product containing a base_form-less unit cannot decompose;
+        the sibling generator yields nothing rather than raising."""
+        graph = get_default_graph().copy()
+        bare = Unit(
+            name='bare_volume', dimension=Dimension.volume, aliases=('bv',))
+        graph.register_unit(bare)
+        product = UnitProduct.from_unit(bare)
+        self.assertEqual(list(graph._base_form_siblings(product)), [])
+
+    def test_siblings_guard_on_malformed_product(self):
+        """The generator's decomposition guard: an object whose
+        to_base_form raises yields nothing (parity with the identical
+        guard in _convert_via_base_form)."""
+        graph = get_default_graph().copy()
+
+        class _Broken:
+            def to_base_form(self):
+                raise TypeError("malformed")
+
+        self.assertEqual(list(graph._base_form_siblings(_Broken())), [])
+
+    def test_scaled_product_sibling_ratio(self):
+        """kilometer³ decomposes with prefactor 1e9; the liter sibling map
+        must carry the full ×1e12 ratio."""
+        graph = get_default_graph().copy()
+        km3 = parse_unit('kilometer^3')
+        siblings = dict(graph._base_form_siblings(km3))
+        self.assertIn(units.liter, siblings)
+        self.assertAlmostEqual(
+            siblings[units.liter](1.0) / 1e12, 1.0, places=9)
 
 
 if __name__ == '__main__':

--- a/ucon/conversion.py
+++ b/ucon/conversion.py
@@ -757,7 +757,21 @@ class Graph:
         # Both plain Units
         if isinstance(src, Unit) and not isinstance(src, UnitProduct):
             if isinstance(dst, Unit) and not isinstance(dst, UnitProduct):
-                result = self._convert_units(src=src, dst=dst)
+                try:
+                    result = self._convert_units(src=src, dst=dst)
+                except ConversionNotFound as unit_miss:
+                    # A package may bind a unit to a composite expression
+                    # (edge dst = "meter^3"); such product edges are
+                    # invisible to unit-level BFS. Retry in product space,
+                    # where base-form sibling links unify composite nodes
+                    # with named units. Only failed lookups take this path.
+                    try:
+                        result = self._bfs_product_path(
+                            src=UnitProduct.from_unit(src),
+                            dst=UnitProduct.from_unit(dst),
+                        )
+                    except ConversionNotFound:
+                        raise unit_miss
                 self._conversion_cache[cache_key] = result
                 return result
 
@@ -880,6 +894,43 @@ class Graph:
             f"No cross-dimensional path from {start} to {target}"
         )
 
+    def _product_from_key(self, key: tuple) -> UnitProduct | None:
+        """Reconstruct a UnitProduct from a product-edge key.
+
+        Product-edge neighbors are discovered by key alone; rebuilding the
+        product lets the search continue expanding from them (unit edges,
+        base-form siblings). Returns ``None`` when any unit name in the key
+        does not resolve in this graph's registry.
+        """
+        factors = {}
+        for name, _dim, scale, exp in key:
+            unit = self._name_registry_cs.get(name) or self._name_registry.get(name.lower())
+            if unit is None:
+                return None
+            factors[UnitFactor(unit, scale)] = exp
+        return UnitProduct(factors)
+
+    def _base_form_siblings(self, product: UnitProduct):
+        """Yield ``(unit, map)`` for registered units sharing *product*'s base form.
+
+        A product like ``meter³`` and a registered unit like ``liter``
+        decompose to the same base-unit signature; they are the same
+        physical node up to the ratio of prefactors. Yields each such unit
+        with the ``LinearMap`` taking product-values to unit-values.
+        """
+        try:
+            base, prefactor = product.to_base_form()
+        except (AttributeError, TypeError):
+            return
+        sig = tuple(sorted((u.name, e) for u, e in base.items()))
+        for unit in set(self._name_registry.values()):
+            bf = unit.base_form
+            if bf is None or not bf.prefactor:
+                continue
+            unit_sig = tuple(sorted((u.name, e) for u, e in bf.factors))
+            if unit_sig == sig:
+                yield unit, LinearMap(prefactor / bf.prefactor)
+
     def _bfs_product_path(self, *, src: UnitProduct, dst: UnitProduct) -> Map:
         """
         BFS to find conversion path through product AND unit edges.
@@ -887,7 +938,10 @@ class Graph:
         Used for cross-dimension conversions where vectors match but dimensions differ
         (e.g., gallon → liter → m³).
 
-        Traverses both product edges and unit edges (for single-unit products).
+        Traverses product edges, unit edges (for single-unit products), and
+        base-form sibling links (a product node and a registered unit with
+        the same base-form signature are the same node up to a prefactor
+        ratio — e.g. ``meter³`` ↔ ``liter``).
         """
         src_key = self._product_key(src)
         dst_key = self._product_key(dst)
@@ -912,8 +966,7 @@ class Graph:
                         continue
 
                     composed = edge_map @ current_map
-                    # We don't have the UnitProduct for neighbor_key, but we can reconstruct later
-                    visited[neighbor_key] = (composed, None)
+                    visited[neighbor_key] = (composed, self._product_from_key(neighbor_key))
 
                     if neighbor_key == dst_key:
                         return composed
@@ -947,6 +1000,26 @@ class Graph:
                                 return composed
 
                             queue.append(neighbor_key)
+
+            # Base-form siblings: a product node and a registered unit with
+            # the same base-form signature are the same physical node up to
+            # a prefactor ratio (meter³ ↔ liter). This is what makes an edge
+            # bound to a composite expression reachable from named units.
+            if current_product is not None:
+                for sibling, sibling_map in self._base_form_siblings(current_product):
+                    neighbor_prod = UnitProduct.from_unit(sibling)
+                    neighbor_key = self._product_key(neighbor_prod)
+
+                    if neighbor_key in visited:
+                        continue
+
+                    composed = sibling_map @ current_map
+                    visited[neighbor_key] = (composed, neighbor_prod)
+
+                    if neighbor_key == dst_key:
+                        return composed
+
+                    queue.append(neighbor_key)
 
         raise ConversionNotFound(f"No product path from {src} to {dst}")
 


### PR DESCRIPTION
Closes #280 (narrow pass — see scope note).

## The defect

A package binding a unit to a composite SI expression (edge `dst = "meter^3"`) created a node invisible to unit-level path search: `us_gallon → meter^3` converted, `meter^3 → liter` converted, but `us_gallon → liter` raised `ConversionNotFound`. One hop worked; two hops through the composite node did not.

## The fix — two pieces in `ucon/conversion.py`

1. **Base-form sibling links in product-space BFS.** A product node and a registered unit sharing the same base-form signature are the same physical node up to a prefactor ratio (`meter³ ↔ liter` at ×1000). `_bfs_product_path` now expands these links, and `_product_from_key` reconstructs products for product-edge-discovered nodes (which previously dead-ended as `None`). Precision note from coverage work: the catalog happens to ship a `liter → meter^3` product edge, so the original reproduction is served by piece 2 alone; the sibling links are load-bearing for composites *without* a catalog product edge (pinned by a `kilometer^3` end-to-end test).
2. **Unit-level fallback into product space.** `convert()`'s Unit/Unit path retries via `_bfs_product_path` on `ConversionNotFound`, re-raising the original error if product space also fails.

Only previously-failing lookups can change outcome: the fallback fires exclusively after `ConversionNotFound`, and sibling links only add reachability.

## Scope note — the deliberate split

`__eq__` across the `Unit`/`UnitProduct` boundary is untouched: `parse_unit("meter^3") == liter` remains `False`. Flipping a public equality from `False` to `True` is observable behavior change, and canonical node identity is being rebuilt in the next major anyway (#280 stays open for that fuller pass, or closes here with the equality half re-filed — maintainer's call; body says "Closes" for the narrow reading).

## Verification

- 20 tests (`tests/ucon/conversion/test_composite_endpoints.py`), with 100% line+branch coverage of the new code: the exact issue reproduction, the inverse path, the unchanged direct path, `__eq__` untouched, genuinely-unreachable pairs still refusing, the sibling/key-reconstruction primitives and their graceful-degradation branches (unresolvable keys, undecomposable products), fallback-result caching, `DimensionMismatch` not swallowed, original-error preservation, a three-hop path mixing all edge kinds, the sibling-only `kilometer^3` path, and a scaled-product ratio check.
- Full suite: 3145 passed, 0 failed — zero regressions.
- CHANGELOG entry under Unreleased/Fixed.

Related: populating CGS `base_form`s (#283) extends this fix's coverage to CGS units for free — every sibling link derives from `base_form`.


