### PR TITLE
types the disjoint-roots refusal as DisjointKinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Disjoint kind roots now raise a typed refusal.** (#281)
+  `KindLattice.lca` on kinds from disjoint trees raised a bare
+  `ValueError` — the one kind-layer refusal outside the typed
+  `KindError` taxonomy, with no payload and indistinguishable from a
+  programming error. It now raises `DisjointKinds`, which carries
+  `left`/`right` attributes and subclasses **both** `KindError` and
+  `ValueError`, so `except KindError` handlers start working while every
+  existing `except ValueError` handler keeps working. Exported via
+  `ucon.kinds` beside the other kind exceptions.
+
+## [2.1.4] - 2026-09-09
+
+### Fixed
+
 - **Paths through composite edge endpoints now resolve.** (#280) A package
   binding a unit to a composite SI expression (edge `dst = "meter^3"`)
   created a node invisible to unit-level path search: `us_gallon →
@@ -2619,6 +2633,7 @@ Deprecated surfaces are scheduled for removal in v2.0.
 - Initial commit
 
 <!-- Links -->
+[2.1.4]: https://github.com/withtwoemms/ucon/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/withtwoemms/ucon/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/withtwoemms/ucon/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/withtwoemms/ucon/compare/2.1.0...2.1.1

--- a/tests/ucon/kinds/test_lca.py
+++ b/tests/ucon/kinds/test_lca.py
@@ -9,9 +9,11 @@ import pytest
 
 from ucon.dimension import LENGTH, MASS, TIME
 from ucon.kinds import (
+    DisjointKinds,
     JoinPolicy,
     JoinRefused,
     Kind,
+    KindError,
     KindLattice,
     lca as module_lca,
 )
@@ -62,11 +64,39 @@ def test_lca_across_multiple_levels():
 
 
 def test_lca_disjoint_trees_raises_value_error():
+    # Backward compatibility (#281): pre-2.1.x handlers caught ValueError;
+    # DisjointKinds subclasses it, so this must keep passing unchanged.
     energy = Kind("energy", dimension=ENERGY_DIM)
     power = Kind("power", dimension=POWER_DIM)
     lat = KindLattice([energy, power])
     with pytest.raises(ValueError, match="no common ancestor"):
         lat.lca(energy, power)
+
+
+def test_lca_disjoint_roots_raises_typed_refusal():
+    """#281: disjoint roots yield a typed KindError verdict, not a bare
+    ValueError — same dimension, two roots, no common ancestor."""
+    a = Kind("a", dimension=ENERGY_DIM)
+    b = Kind("b", dimension=ENERGY_DIM)
+    lat = KindLattice([a, b])
+    with pytest.raises(DisjointKinds) as exc_info:
+        lat.lca(a, b)
+    assert exc_info.value.left == a
+    assert exc_info.value.right == b
+
+
+def test_disjoint_kinds_is_catchable_as_kind_error():
+    """#281: `except KindError` handlers now see the disjoint-roots verdict."""
+    a = Kind("a", dimension=ENERGY_DIM)
+    b = Kind("b", dimension=ENERGY_DIM)
+    lat = KindLattice([a, b])
+    try:
+        lat.lca(a, b)
+    except KindError as e:
+        assert isinstance(e, DisjointKinds)
+        assert isinstance(e, ValueError)
+    else:  # pragma: no cover
+        pytest.fail("expected DisjointKinds")
 
 
 def test_lca_surfaces_refuse_policy():

--- a/ucon/kinds/__init__.py
+++ b/ucon/kinds/__init__.py
@@ -19,6 +19,7 @@ v2.0.0 the lattice becomes a member of ``UnitSystem``.
 from ucon.kinds.exceptions import (
     AliasCollision,
     CrossDimensionParent,
+    DisjointKinds,
     JoinRefused,
     KindCycle,
     KindError,
@@ -46,4 +47,5 @@ __all__ = [
     "AliasCollision",
     "KindNotFound",
     "JoinRefused",
+    "DisjointKinds",
 ]

--- a/ucon/kinds/exceptions.py
+++ b/ucon/kinds/exceptions.py
@@ -27,6 +27,7 @@ __all__ = [
     "AliasCollision",
     "JoinRefused",
     "KindNotFound",
+    "DisjointKinds",
 ]
 
 
@@ -111,6 +112,25 @@ class KindNotFound(KindError):
     def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"Unknown kind: {name!r}")
+
+
+class DisjointKinds(KindError, ValueError):
+    """Two kinds belong to disjoint trees — no common ancestor exists.
+
+    Raised by :meth:`KindLattice.lca` when the operands' ancestor chains
+    never intersect. Distinct roots cannot be joined; this is a verdict
+    ("independent kinds, no conversion"), not a programming error, so it
+    joins the :class:`KindError` taxonomy with ``left``/``right``
+    attributes for diagnostics. It also subclasses :class:`ValueError`
+    so existing ``except ValueError`` handlers continue to work.
+    """
+
+    def __init__(self, left: "Kind", right: "Kind") -> None:
+        self.left = left
+        self.right = right
+        super().__init__(
+            f"Kinds {left.name!r} and {right.name!r} have no common ancestor"
+        )
 
 
 class JoinRefused(KindError):

--- a/ucon/kinds/lattice.py
+++ b/ucon/kinds/lattice.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 from ucon.kinds.exceptions import (
     AliasCollision,
     CrossDimensionParent,
+    DisjointKinds,
     JoinRefused,
     KindCycle,
     KindNotFound,
@@ -188,18 +189,18 @@ class KindLattice:
         ------
         KindNotFound
             If ``a`` or ``b`` refer to unregistered kinds.
-        ValueError
+        DisjointKinds
             If ``a`` and ``b`` belong to disjoint trees (no common
-            ancestor). Distinct roots cannot be joined.
+            ancestor). Distinct roots cannot be joined. Subclasses both
+            :class:`KindError` and :class:`ValueError`, so pre-2.1.x
+            ``except ValueError`` handlers keep working.
         """
         chain_a = self.ancestors(a)
         chain_b_set = {k.name for k in self.ancestors(b)}
         for node in chain_a:
             if node.name in chain_b_set:
                 return node, node.join_policy
-        raise ValueError(
-            f"Kinds {a.name!r} and {b.name!r} have no common ancestor"
-        )
+        raise DisjointKinds(a, b)
 
     def join(self, a: Kind, b: Kind) -> Kind:
         """LCA-based join that honors ``join_policy``.


### PR DESCRIPTION
Closes #281 (the minimal contract repair; the fuller ⊤_d design lands with the kind-stratum rework, as recorded on the issue).

## Fix

`KindLattice.lca` on kinds from disjoint trees raised a bare `ValueError` — the one kind-layer refusal outside the typed `KindError` taxonomy: wrong type (`except KindError` handlers crash instead of refusing), no payload, indistinguishable from a programming error.

It now raises `DisjointKinds`, which:

- carries `left`/`right` attributes, matching the exceptions module's structured-payload convention (`JoinRefused.left/.right/.parent`, `KindNotFound.name`)
- subclasses **both** `KindError` and `ValueError` — dual inheritance keeps every pre-existing `except ValueError` handler working while `except KindError` starts working
- preserves the exact message text ("no common ancestor"), so message-matching callers are unaffected
- is exported via `ucon.kinds` beside the other kind exceptions

Fully backward compatible: no currently-succeeding input changes behavior, and the pre-existing disjoint-roots test (`pytest.raises(ValueError, match="no common ancestor")`) passes **unchanged** — which is the compatibility proof.

## Verification

- 3 tests: the unchanged legacy `ValueError` test, the typed verdict with payload (same-dimension two-root case from the issue), and catchability as `KindError`
- Full suite green; CHANGELOG entry under Unreleased (with the 2.1.4 re-sectioning folded into this PR's rebase)
