### PR TITLE
makes identical-object Kind re-add idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Re-adding an identical `Kind` object is now an idempotent no-op.**
+  (#284) `KindLattice._add` distinguished name collisions from alias
+  collisions with a guard that skipped the identical-object case, so the
+  same `Kind` appearing twice (e.g. once in a constructor list and once
+  via an overlapping collection) fell through to a self-referential
+  `AliasCollision` ("Alias 'foo' collides with existing entry 'foo'") —
+  no alias involved, and the "collision" was the object with itself.
+  Re-registering the identical object now returns quietly; a *distinct*
+  object with the same name still raises `NameCollision`, and
+  `AliasCollision` is reachable only when an alias is actually involved.
+
+## [2.1.5] - 2026-09-09
+
+### Fixed
+
 - **Disjoint kind roots now raise a typed refusal.** (#281)
   `KindLattice.lca` on kinds from disjoint trees raised a bare
   `ValueError` — the one kind-layer refusal outside the typed
@@ -2633,6 +2648,7 @@ Deprecated surfaces are scheduled for removal in v2.0.
 - Initial commit
 
 <!-- Links -->
+[2.1.5]: https://github.com/withtwoemms/ucon/compare/2.1.4...2.1.5
 [2.1.4]: https://github.com/withtwoemms/ucon/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/withtwoemms/ucon/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/withtwoemms/ucon/compare/2.1.1...2.1.2

--- a/tests/ucon/kinds/test_validation.py
+++ b/tests/ucon/kinds/test_validation.py
@@ -55,6 +55,26 @@ def test_duplicate_primary_name_raises():
     assert exc.value.name == "foo"
 
 
+def test_identical_object_readd_is_idempotent():
+    """#284: the same Kind object appearing twice is harmless — previously
+    this fell through to a self-referential AliasCollision
+    ("Alias 'foo' collides with existing entry 'foo'")."""
+    k = Kind("foo", dimension=ENERGY_DIM, aliases=("f",))
+    lat = KindLattice([k, k])
+    assert lat.get("foo") is k
+    assert lat.get("f") is k
+
+
+def test_distinct_same_name_objects_raise_name_collision():
+    """#284: a *distinct* object with the same name is a NameCollision —
+    never an AliasCollision when no alias is involved."""
+    a = Kind("foo", dimension=ENERGY_DIM)
+    b = Kind("foo", dimension=ENERGY_DIM)
+    with pytest.raises(NameCollision) as exc:
+        KindLattice([a, b])
+    assert exc.value.name == "foo"
+
+
 # --------- alias collisions ---------
 
 def test_alias_collides_with_other_alias():

--- a/tests/ucon/parsing/test_parse_kinds.py
+++ b/tests/ucon/parsing/test_parse_kinds.py
@@ -94,12 +94,12 @@ def test_bad_cross_dimension_raises_crossdimensionparent():
 
 
 def test_bad_name_collision_raises_collision_error():
-    # The parser hands duplicate-name entries to the lattice as a single
-    # rebuilt Kind, so the lattice surfaces an AliasCollision rather
-    # than a NameCollision. Either is acceptable evidence that the
-    # loader rejected the bad fixture; the canonical NameCollision path
-    # is exercised directly in tests/ucon/kinds/test_validation.py.
-    with pytest.raises((NameCollision, AliasCollision)):
+    # The parser itself rejects duplicate [[kinds]] names (#284): it is
+    # the only layer that sees both declarations, since it collapses them
+    # into one rebuilt Kind before the lattice ever loads. (Previously the
+    # rejection happened downstream by accident, as a self-referential
+    # AliasCollision from the lattice's identical-object double-add.)
+    with pytest.raises(NameCollision):
         load_kinds_file(FIXTURES / "bad_name_collision.ucon.toml")
 
 

--- a/ucon/kinds/lattice.py
+++ b/ucon/kinds/lattice.py
@@ -72,10 +72,18 @@ class KindLattice:
     # ---------- ingestion / indexing ----------
 
     def _add(self, kind: Kind) -> None:
-        """Register a kind in the flat namespace. Raises on collision."""
+        """Register a kind in the flat namespace. Raises on collision.
+
+        Re-adding the *identical object* is an idempotent no-op — its name
+        and aliases are already registered. A distinct object with the same
+        name raises :class:`NameCollision`; a name that collides with
+        another kind's alias raises :class:`AliasCollision`.
+        """
         if kind.name in self._index:
             existing = self._index[kind.name]
-            if existing.name == kind.name and existing is not kind:
+            if existing is kind:
+                return
+            if existing.name == kind.name:
                 raise NameCollision(kind.name)
             raise AliasCollision(kind.name, existing.name)
         self._by_name[kind.name] = kind

--- a/ucon/parsing/kinds.py
+++ b/ucon/parsing/kinds.py
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-from ucon.kinds import JoinPolicy, Kind, KindLattice
+from ucon.kinds import JoinPolicy, Kind, KindLattice, NameCollision
 from ucon.parsing.dimensions import parse_dimension
 
 
@@ -82,6 +82,15 @@ def parse_kinds_payload(payload: dict[str, Any]) -> KindLattice:
             raise ValueError(f"Kind entry missing 'name': {raw!r}")
         if "dimension" not in raw:
             raise ValueError(f"Kind {name!r} missing 'dimension'")
+        if name in rough:
+            # Two [[kinds]] entries declaring the same name. Historically
+            # this was caught downstream by accident: the parser collapsed
+            # both entries into one Kind and the lattice's double-add of
+            # the identical object raised a (self-referential)
+            # AliasCollision. The lattice's identical-object re-add is an
+            # idempotent no-op as of #284, so the loader — the only layer
+            # that sees both declarations — rejects the duplicate itself.
+            raise NameCollision(name)
         rough[name] = raw
         order.append(name)
 


### PR DESCRIPTION
Closes #284.

## Fix

`KindLattice._add`'s collision guard skipped the identical-object case (`existing is not kind`), so the same `Kind` object appearing twice — once in a constructor list and once via an overlapping collection — fell through to a self-referential `AliasCollision`:

```
AliasCollision: Alias 'dose' collides with existing entry 'dose'
```

No alias involved; the "collision" was the object with itself.

Resolution (the issue's option 1, idempotent no-op): re-registering the *identical object* returns quietly — its name and aliases are already registered, so the operation is harmless set-like ingestion. A **distinct** object with the same name still raises `NameCollision`, and `AliasCollision` is now reachable only when an alias is actually involved.

Only a previously-raising input changes behavior (failure → success); every collision that involves two distinct definitions still refuses exactly as before.

## Verification

- 2 new tests: identical-object re-add resolves through both name and alias; distinct same-name objects still `NameCollision`
- Full kinds suite: 154 passed; CHANGELOG entry under Unreleased (with the `[2.1.5]` re-sectioning folded into this PR's rebase)


## Layering fix surfaced by CI

The full matrix caught a dependency the local kinds-suite run missed: the *parser's* rejection of duplicate `[[kinds]]` names was happening **by accident** — `parse_kinds_payload` collapses duplicate entries into one rebuilt `Kind` and registered it twice, and the lattice's self-referential `AliasCollision` (the very bug this PR fixes) was the only thing refusing the bad file. With idempotent re-add, the bad fixture loaded silently.

Fixed at the correct layer: the parser — the only layer that sees both declarations — now raises `NameCollision` itself on a duplicate name. The parse test tightens from "either collision type" (with an apologetic comment) to exactly `NameCollision`. Full suite: 3149 passed.
