### PR TITLE
populates exact SI base_forms for mechanical CGS units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mechanical CGS units now carry exact SI-factored `base_form`s.**
+  (#283) `base_form is None` conflated three unrelated causes: chart
+  structure (celsius, dB — no factorization exists), basis scoping
+  (dyne — an exact factorization exists but was never recorded), and
+  pseudo-dimensions (degree). Eight purely multiplicative CGS-mechanical
+  units — dyne, erg, poise, stokes, barye, galileo, kayser, langley —
+  are now populated with their exact SI equivalents, so `None` recovers
+  meaning: either no factorization exists, or (electromagnetic CGS:
+  gauss, maxwell, statvolt, …) the factorization is dimensionally
+  ill-typed across bases and conversion routes through `RebasedUnit`
+  edges. The `BaseForm` contract docstring now states all of this
+  explicitly, including: never infer chart/scale structure from
+  `base_form is None`. `enforce_dimensions` cross-basis coercion still
+  lands on named SI units (joule, pascal·second) — the graph route is
+  preferred and the algebraic decomposition is a fallback — and every
+  `base_form` consumer (base-form conversion shortcut, composite-path
+  sibling links from #280) now covers these CGS units.
+
+## [2.1.6] - 2026-09-09
+
+### Fixed
+
 - **Re-adding an identical `Kind` object is now an idempotent no-op.**
   (#284) `KindLattice._add` distinguished name collisions from alias
   collisions with a guard that skipped the identical-object case, so the
@@ -19,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Re-registering the identical object now returns quietly; a *distinct*
   object with the same name still raises `NameCollision`, and
   `AliasCollision` is reachable only when an alias is actually involved.
+  Relatedly, the kinds parser now rejects duplicate `[[kinds]]` names
+  itself (`NameCollision`) — that rejection previously happened only by
+  accident, via the self-referential lattice collision this release
+  fixes. *(Entry added retroactively with the 2.1.7 re-sectioning.)*
 
 ## [2.1.5] - 2026-09-09
 
@@ -2648,6 +2674,7 @@ Deprecated surfaces are scheduled for removal in v2.0.
 - Initial commit
 
 <!-- Links -->
+[2.1.6]: https://github.com/withtwoemms/ucon/compare/2.1.5...2.1.6
 [2.1.5]: https://github.com/withtwoemms/ucon/compare/2.1.4...2.1.5
 [2.1.4]: https://github.com/withtwoemms/ucon/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/withtwoemms/ucon/compare/2.1.2...2.1.3

--- a/tests/ucon/test_cgs_base_forms.py
+++ b/tests/ucon/test_cgs_base_forms.py
@@ -1,0 +1,73 @@
+# Copyright 2026 The Radiativity Company
+# Licensed under the Apache License, Version 2.0
+
+"""Regression guard for mechanical-CGS base_forms (issue #283).
+
+``base_form is None`` historically conflated three unrelated causes:
+chart structure (celsius, dB — no factorization exists), basis scoping
+(dyne — an exact factorization exists but was never recorded), and
+pseudo-dimensions (degree). The resolution: populate exact SI-factored
+base_forms for the purely multiplicative CGS-mechanical units, so that
+``None`` carries meaning (no factorization exists, or the factorization
+is dimensionally ill-typed across bases) rather than accident.
+
+The electromagnetic CGS units stay ``None`` deliberately: their
+dimensional exponents differ from SI's, and conversion routes through
+``RebasedUnit`` edges.
+"""
+
+import pytest
+
+from ucon import Number, units
+
+
+# name -> (prefactor, {base unit name: exponent}) — all exact by definition
+MECHANICAL_CGS = {
+    "dyne":    (1e-05,   {"meter": 1.0, "kilogram": 1.0, "second": -2.0}),
+    "erg":     (1e-07,   {"meter": 2.0, "kilogram": 1.0, "second": -2.0}),
+    "poise":   (0.1,     {"kilogram": 1.0, "meter": -1.0, "second": -1.0}),
+    "stokes":  (0.0001,  {"meter": 2.0, "second": -1.0}),
+    "barye":   (0.1,     {"kilogram": 1.0, "meter": -1.0, "second": -2.0}),
+    "galileo": (0.01,    {"meter": 1.0, "second": -2.0}),
+    "kayser":  (100.0,   {"meter": -1.0}),
+    "langley": (41840.0, {"kilogram": 1.0, "second": -2.0}),
+}
+
+# EM CGS units whose base_form must STAY None (cross-basis scoping)
+EM_CGS_NULL = (
+    "gauss", "maxwell", "oersted", "statvolt", "statohm", "statampere",
+    "statcoulomb", "statfarad", "abvolt", "abohm", "abcoulomb", "abfarad",
+    "abhenry", "biot", "gilbert", "debye",
+)
+
+
+@pytest.mark.parametrize("name", sorted(MECHANICAL_CGS))
+def test_mechanical_cgs_base_form_exact(name):
+    prefactor, factors = MECHANICAL_CGS[name]
+    bf = getattr(units, name).base_form
+    assert bf is not None, f"{name} should carry an SI-factored base_form"
+    assert bf.prefactor == prefactor
+    assert {u.name: e for u, e in bf.factors} == factors
+
+
+@pytest.mark.parametrize("name", EM_CGS_NULL)
+def test_em_cgs_base_form_stays_none(name):
+    unit = getattr(units, name, None)
+    if unit is None:
+        pytest.skip(f"{name} not in catalog")
+    assert unit.base_form is None, (
+        f"{name} is a cross-basis EM unit; its base_form must stay None "
+        "(conversion routes through RebasedUnit edges)"
+    )
+
+
+def test_dyne_conversion_unchanged():
+    """The graph edge route that always worked keeps working."""
+    result = Number(1, units.dyne).to(units.newton)
+    assert result.quantity == pytest.approx(1e-05, rel=1e-12)
+
+
+def test_affine_and_log_units_stay_none():
+    """Chart-structural None is untouched."""
+    for name in ("celsius", "fahrenheit", "decibel", "pH"):
+        assert getattr(units, name).base_form is None

--- a/tests/ucon/test_checking.py
+++ b/tests/ucon/test_checking.py
@@ -872,5 +872,54 @@ class TestKindDispatchWithoutContext(unittest.TestCase):
             _active.reset(token)
 
 
+class TestCoerceToSiRouting(unittest.TestCase):
+    """Routing coverage for the #283 _coerce_to_si restructure.
+
+    The function has four routes: SI unit → immediate algebraic return;
+    all-SI product → immediate algebraic return; cross-basis with SI
+    base_form → graph preferred, algebraic fallback (covered in
+    TestEnforceDimensionsCrossBasis / TestCoerceToSiAlgebraic); and
+    no-base_form / uncoercible → graph, else unchanged.
+    """
+
+    def test_si_unit_with_base_form_returns_algebraic(self):
+        """An SI-dimensioned unit (foot) coerces algebraically at once."""
+        from ucon.checking import _coerce_to_si
+        n = Number(2.0, units.foot)
+        result = _coerce_to_si(n)
+        self.assertIsNot(result, n)
+        self.assertAlmostEqual(result.quantity, 2 * 0.3048)
+        self.assertIsInstance(result.unit, UnitProduct)
+
+    def test_all_si_product_returns_algebraic(self):
+        """A product whose factors are all SI-dimensioned (foot²) coerces
+        algebraically at once."""
+        from ucon.checking import _coerce_to_si
+        from ucon.resolver import parse_unit
+        n = Number(1.0, parse_unit('foot^2'))
+        result = _coerce_to_si(n)
+        self.assertIsNot(result, n)
+        self.assertAlmostEqual(result.quantity, 0.3048 ** 2)
+
+    def test_unit_without_base_form_routes_to_graph(self):
+        """An EM CGS unit (gauss, base_form=None by design — #283) skips
+        the algebraic path entirely; with no graph coercion available the
+        value returns unchanged rather than raising."""
+        from ucon.checking import _coerce_to_si
+        n = Number(1.0, units.gauss)
+        result = _coerce_to_si(n)
+        self.assertEqual(result.quantity, 1.0)
+        self.assertEqual(getattr(result.unit, 'name', None), 'gauss')
+
+    def test_uncoercible_product_returns_unchanged(self):
+        """A product containing a base_form-less factor (gauss·s) cannot
+        coerce algebraically; when the graph also has no route, the
+        original Number is returned untouched — never a partial result."""
+        from ucon.checking import _coerce_to_si
+        n = Number(1.0, units.gauss * units.second)
+        result = _coerce_to_si(n)
+        self.assertIs(result, n)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ucon/test_checking.py
+++ b/tests/ucon/test_checking.py
@@ -14,6 +14,17 @@ else:
     from typing_extensions import Annotated
 
 from ucon import Dimension, Number, units, enforce_dimensions, DimensionConstraint, KindConstraint
+from ucon._active import _active
+from ucon.checking import (
+    _coerce_product_to_si,
+    _coerce_to_si,
+    _coerce_via_graph,
+    _dimensions_compatible,
+    _get_dimension,
+)
+from ucon.dimension import Dimension as DimClass
+from ucon.graph import ConversionNotFound, get_default_graph
+from ucon.resolver import parse_unit
 from ucon.basis import Basis, Vector
 from ucon.basis.builtin import SI, CGS
 from ucon.core import Unit, UnitProduct, UnitFactor, Scale, BaseForm
@@ -161,13 +172,11 @@ class TestGetDimension(unittest.TestCase):
     """Tests for the _get_dimension helper."""
 
     def test_extracts_dimension_from_unit_product(self):
-        from ucon.checking import _get_dimension
         n = units.meter(5)
         dim = _get_dimension(n)
         self.assertEqual(dim, Dimension.length)
 
     def test_raises_type_error_for_non_unit(self):
-        from ucon.checking import _get_dimension
         # Construct a Number whose .unit is neither Unit nor UnitProduct
         n = Number.__new__(Number)
         object.__setattr__(n, '_quantity', 1.0)
@@ -182,16 +191,13 @@ class TestDimensionsCompatible(unittest.TestCase):
     """Tests for the _dimensions_compatible function."""
 
     def test_same_dimension_is_compatible(self):
-        from ucon.checking import _dimensions_compatible
         self.assertTrue(_dimensions_compatible(Dimension.length, Dimension.length))
 
     def test_different_dimension_same_basis_incompatible(self):
-        from ucon.checking import _dimensions_compatible
         self.assertFalse(_dimensions_compatible(Dimension.length, Dimension.time))
 
     def test_cross_basis_compatible(self):
         """CGS dynamic_viscosity is compatible with SI dynamic_viscosity."""
-        from ucon.checking import _dimensions_compatible
         cgs_dim = units.poise.dimension
         si_dim = Dimension.dynamic_viscosity
         self.assertNotEqual(cgs_dim.vector.basis, si_dim.vector.basis)
@@ -199,16 +205,12 @@ class TestDimensionsCompatible(unittest.TestCase):
 
     def test_cross_basis_incompatible(self):
         """CGS dynamic_viscosity is NOT compatible with SI energy."""
-        from ucon.checking import _dimensions_compatible
         cgs_dim = units.poise.dimension
         si_dim = Dimension.energy
         self.assertFalse(_dimensions_compatible(cgs_dim, si_dim))
 
     def test_no_transform_path_returns_false(self):
         """Dimensions with no BasisGraph path are incompatible."""
-        from ucon.checking import _dimensions_compatible
-        from ucon.dimension import Dimension as DimClass
-        from ucon.basis import Basis, Vector
 
         # Create a dimension on a fictitious basis with no transforms registered
         fake_basis = Basis("FakeBasis", ["x", "y"])
@@ -283,7 +285,6 @@ class TestDimensionsCompatibleAdversarial(unittest.TestCase):
 
     def test_si_actual_vs_cgs_expected(self):
         """SI actual, CGS expected — only the expected side needs transform."""
-        from ucon.checking import _dimensions_compatible
         si_force = Dimension.force
         cgs_force = units.dyne.dimension
         # actual is SI (skip transform), expected is CGS (needs transform)
@@ -291,12 +292,10 @@ class TestDimensionsCompatibleAdversarial(unittest.TestCase):
 
     def test_si_actual_vs_cgs_expected_incompatible(self):
         """SI energy vs CGS force — different physical quantities."""
-        from ucon.checking import _dimensions_compatible
         self.assertFalse(_dimensions_compatible(Dimension.energy, units.dyne.dimension))
 
     def test_both_non_si_same_basis_different_dimensions(self):
         """Two CGS dimensions on same basis, different vectors — should be False."""
-        from ucon.checking import _dimensions_compatible
         cgs_force = units.dyne.dimension
         cgs_viscosity = units.poise.dimension
         self.assertFalse(_dimensions_compatible(cgs_force, cgs_viscosity))
@@ -310,7 +309,6 @@ class TestCoerceToSiAlgebraic(unittest.TestCase):
 
     def test_plain_unit_with_si_base_form(self):
         """Non-SI unit with SI base_form factors coerces algebraically (lines 87-93)."""
-        from ucon.checking import _coerce_to_si
         basis = self._make_custom_basis()
         dim = Dimension(Vector(basis, (1, 0, 0)), name='talg_length')
         bf = BaseForm(factors=((units.meter, 1.0),), prefactor=0.3048)
@@ -322,7 +320,6 @@ class TestCoerceToSiAlgebraic(unittest.TestCase):
 
     def test_plain_unit_with_si_base_form_uncertainty(self):
         """Uncertainty is scaled by base_form prefactor."""
-        from ucon.checking import _coerce_to_si
         basis = self._make_custom_basis()
         dim = Dimension(Vector(basis, (1, 0, 0)), name='talg_length2')
         bf = BaseForm(factors=((units.meter, 1.0),), prefactor=0.3048)
@@ -333,7 +330,6 @@ class TestCoerceToSiAlgebraic(unittest.TestCase):
 
     def test_plain_unit_with_non_si_base_form_falls_to_graph(self):
         """Non-SI base_form factors fall through to graph path (line 89 false)."""
-        from ucon.checking import _coerce_to_si
         basis = self._make_custom_basis()
         dim = Dimension(Vector(basis, (1, 0, 0)), name='talg_x')
         non_si_base = Unit(name='talg_base', dimension=dim, aliases=('tb',))
@@ -346,7 +342,6 @@ class TestCoerceToSiAlgebraic(unittest.TestCase):
 
     def test_plain_unit_no_base_form_falls_to_graph(self):
         """Unit with base_form=None falls through to graph path."""
-        from ucon.checking import _coerce_to_si
         # CGS units have base_form=None
         n = Number(1.0, units.dyne)
         result = _coerce_to_si(n)
@@ -356,7 +351,6 @@ class TestCoerceToSiAlgebraic(unittest.TestCase):
 
     def test_product_with_si_base_form_coerces_algebraically(self):
         """UnitProduct whose factors all have SI base_forms coerces (lines 83-85)."""
-        from ucon.checking import _coerce_to_si
         basis = self._make_custom_basis()
         bf_len = BaseForm(factors=((units.meter, 1.0),), prefactor=0.3048)
         bf_time = BaseForm(factors=((units.second, 1.0),), prefactor=1.0)
@@ -374,7 +368,6 @@ class TestCoerceProductToSiAdversarial(unittest.TestCase):
 
     def test_factor_without_base_form_returns_unchanged(self):
         """Product factor with base_form=None aborts algebraic coercion (line 106-107)."""
-        from ucon.checking import _coerce_product_to_si
         basis = Basis('TestProd', ['x', 'y'])
         dim = Dimension(Vector(basis, (1, 0)), name='tp_x')
         no_bf = Unit(name='tp_nobase', dimension=dim, aliases=('tnb',))  # base_form=None
@@ -385,7 +378,6 @@ class TestCoerceProductToSiAdversarial(unittest.TestCase):
 
     def test_factor_with_non_si_base_form_returns_unchanged(self):
         """Product factor with non-SI base_form factors returns unchanged (line 108-109)."""
-        from ucon.checking import _coerce_product_to_si
         basis = Basis('TestProd2', ['x', 'y'])
         dim = Dimension(Vector(basis, (1, 0)), name='tp2_x')
         foreign_base = Unit(name='tp2_base', dimension=dim, aliases=('t2b',))
@@ -398,7 +390,6 @@ class TestCoerceProductToSiAdversarial(unittest.TestCase):
 
     def test_successful_product_coercion_with_uncertainty(self):
         """Product coercion scales uncertainty by abs(combined_prefactor) (line 115)."""
-        from ucon.checking import _coerce_product_to_si
         basis = Basis('TestProd3', ['length', 'time'])
         bf_len = BaseForm(factors=((units.meter, 1.0),), prefactor=100.0)
         bf_time = BaseForm(factors=((units.second, 1.0),), prefactor=60.0)
@@ -423,14 +414,12 @@ class TestCoerceViaGraphAdversarial(unittest.TestCase):
 
     def test_si_input_returns_unchanged(self):
         """SI unit hits early return (line 137)."""
-        from ucon.checking import _coerce_via_graph
         n = Number(1.0, units.meter)
         result = _coerce_via_graph(n)
         self.assertIs(result, n)
 
     def test_no_transform_path_returns_unchanged(self):
         """Unknown basis with no BasisGraph entry returns unchanged (lines 138-139)."""
-        from ucon.checking import _coerce_via_graph
         fake_basis = Basis('Isolated', ['q'])
         fake_dim = Dimension(Vector(fake_basis, (1,)), name='isolated_q')
         fake_unit = Unit(name='iso_unit', dimension=fake_dim, aliases=('iu',))
@@ -440,7 +429,6 @@ class TestCoerceViaGraphAdversarial(unittest.TestCase):
 
     def test_no_target_in_graph_returns_unchanged(self):
         """Dimension with no units in graph returns unchanged (line 163)."""
-        from ucon.checking import _coerce_via_graph
         n = Number(1.0, units.dyne)
         with patch('ucon.checking.get_default_graph') as mock_gg:
             mock_g = MagicMock()
@@ -451,8 +439,6 @@ class TestCoerceViaGraphAdversarial(unittest.TestCase):
 
     def test_conversion_exception_returns_unchanged(self):
         """graph.convert raising returns unchanged (lines 167-168)."""
-        from ucon.checking import _coerce_via_graph
-        from ucon.graph import get_default_graph, ConversionNotFound
         real_graph = get_default_graph()
         n = Number(1.0, units.dyne)
         with patch('ucon.checking.get_default_graph') as mock_gg:
@@ -465,9 +451,6 @@ class TestCoerceViaGraphAdversarial(unittest.TestCase):
 
     def test_fallback_loop_when_no_coherent_unit(self):
         """Fallback loop (lines 155-160) picks a unit when no prefactor==1.0 exists."""
-        from ucon.checking import _coerce_via_graph
-        from ucon.graph import get_default_graph
-        from ucon.system import active_system
 
         bg = active_system().basis_graph
         cgs_force = units.dyne.dimension
@@ -494,8 +477,6 @@ class TestCoerceViaGraphAdversarial(unittest.TestCase):
 
     def test_uncertainty_propagated_via_conversion_a(self):
         """Uncertainty propagated using conversion.a when available (line 173)."""
-        from ucon.checking import _coerce_via_graph
-        from ucon.graph import get_default_graph
 
         n = Number(1.0, units.dyne, uncertainty=0.1)
         result = _coerce_via_graph(n)
@@ -505,8 +486,6 @@ class TestCoerceViaGraphAdversarial(unittest.TestCase):
 
     def test_uncertainty_none_when_conversion_lacks_a(self):
         """Uncertainty is None when conversion object lacks .a attribute (line 173 else)."""
-        from ucon.checking import _coerce_via_graph
-        from ucon.graph import get_default_graph
         real_graph = get_default_graph()
 
         n = Number(1.0, units.dyne, uncertainty=0.1)
@@ -842,7 +821,6 @@ class TestKindDispatchWithoutContext(unittest.TestCase):
 
     def test_resolve_mul_kind_no_active_context(self):
         """_resolve_mul_kind returns None when no active context exists."""
-        from ucon._active import _active
         ke = Kind("kinetic_energy", dimension=ENERGY)
         pe = Kind("potential_energy", dimension=ENERGY)
         a = Number(10, units.joule, kind=ke)
@@ -856,7 +834,6 @@ class TestKindDispatchWithoutContext(unittest.TestCase):
 
     def test_resolve_add_kind_different_kinds_no_context(self):
         """_resolve_add_kind raises TypeError for different kinds without context."""
-        from ucon._active import _active
         ke = Kind("kinetic_energy", dimension=ENERGY)
         pe = Kind("potential_energy", dimension=ENERGY)
         a = Number(10, units.joule, kind=ke)
@@ -884,7 +861,6 @@ class TestCoerceToSiRouting(unittest.TestCase):
 
     def test_si_unit_with_base_form_returns_algebraic(self):
         """An SI-dimensioned unit (foot) coerces algebraically at once."""
-        from ucon.checking import _coerce_to_si
         n = Number(2.0, units.foot)
         result = _coerce_to_si(n)
         self.assertIsNot(result, n)
@@ -894,8 +870,6 @@ class TestCoerceToSiRouting(unittest.TestCase):
     def test_all_si_product_returns_algebraic(self):
         """A product whose factors are all SI-dimensioned (foot²) coerces
         algebraically at once."""
-        from ucon.checking import _coerce_to_si
-        from ucon.resolver import parse_unit
         n = Number(1.0, parse_unit('foot^2'))
         result = _coerce_to_si(n)
         self.assertIsNot(result, n)
@@ -905,7 +879,6 @@ class TestCoerceToSiRouting(unittest.TestCase):
         """An EM CGS unit (gauss, base_form=None by design — #283) skips
         the algebraic path entirely; with no graph coercion available the
         value returns unchanged rather than raising."""
-        from ucon.checking import _coerce_to_si
         n = Number(1.0, units.gauss)
         result = _coerce_to_si(n)
         self.assertEqual(result.quantity, 1.0)
@@ -915,7 +888,6 @@ class TestCoerceToSiRouting(unittest.TestCase):
         """A product containing a base_form-less factor (gauss·s) cannot
         coerce algebraically; when the graph also has no route, the
         original Number is returned untouched — never a partial result."""
-        from ucon.checking import _coerce_to_si
         n = Number(1.0, units.gauss * units.second)
         result = _coerce_to_si(n)
         self.assertIs(result, n)

--- a/ucon/checking.py
+++ b/ucon/checking.py
@@ -87,10 +87,20 @@ def _coerce_to_si(value: Number, *, system: "UnitSystem | None" = None) -> Numbe
     unit = value.unit
 
     # --- algebraic path (base_form available) ---
+    # For SI-dimensioned units the algebraic result is final. For
+    # cross-basis units (CGS-mechanical dyne, erg, poise, … carry
+    # SI-factored base_forms as of #283) the graph is preferred — it lands
+    # on the *named* coherent SI unit (joule, pascal_second) rather than an
+    # anonymous product — with the algebraic result kept as the fallback
+    # for graphs that cannot reach an SI target.
+    algebraic_fallback: Number | None = None
+
     if isinstance(unit, UnitProduct):
         result = _coerce_product_to_si(value)
         if result is not value:
-            return result
+            if all(uf.unit.dimension.vector.basis == SI for uf in unit.factors):
+                return result
+            algebraic_fallback = result
     elif isinstance(unit, Unit) and unit.base_form is not None:
         bf = unit.base_form
         # Verify factors are SI-basis before using them
@@ -98,10 +108,16 @@ def _coerce_to_si(value: Number, *, system: "UnitSystem | None" = None) -> Numbe
             si_unit = UnitProduct({u: e for u, e in bf.factors})
             si_qty = value.quantity * bf.prefactor
             si_unc = value.uncertainty * bf.prefactor if value.uncertainty else None
-            return Number(si_qty, si_unit, uncertainty=si_unc)
+            result = Number(si_qty, si_unit, uncertainty=si_unc)
+            if unit.dimension.vector.basis == SI:
+                return result
+            algebraic_fallback = result
 
-    # --- graph path (CGS units without SI base_form) ---
-    return _coerce_via_graph(value, system=system)
+    # --- graph path (cross-basis units; named SI targets preferred) ---
+    graph_result = _coerce_via_graph(value, system=system)
+    if graph_result is not value:
+        return graph_result
+    return algebraic_fallback if algebraic_fallback is not None else value
 
 
 def _coerce_product_to_si(value: Number) -> Number:

--- a/ucon/comprehensive.ucon.toml
+++ b/ucon/comprehensive.ucon.toml
@@ -846,6 +846,14 @@ aliases = [
     "Ba",
 ]
 
+[units.base_form]
+prefactor = 0.1
+factors = [
+    ["kilogram", 1.0],
+    ["meter", -1.0],
+    ["second", -2.0],
+]
+
 [[units]]
 name = "biot"
 dimension = "cgs_emu_current"
@@ -1019,6 +1027,13 @@ aliases = [
     "Gal",
 ]
 
+[units.base_form]
+prefactor = 0.01
+factors = [
+    ["meter", 1.0],
+    ["second", -2.0],
+]
+
 [[units]]
 name = "gilbert"
 dimension = "cgs_emu_current"
@@ -1167,6 +1182,12 @@ aliases = [
     "K_wave",
 ]
 
+[units.base_form]
+prefactor = 100.0
+factors = [
+    ["meter", -1.0],
+]
+
 [[units]]
 name = "liter"
 dimension = "volume"
@@ -1203,6 +1224,13 @@ name = "langley"
 dimension = "cgs_radiant_exposure"
 aliases = [
     "Ly_rad",
+]
+
+[units.base_form]
+prefactor = 41840.0
+factors = [
+    ["kilogram", 1.0],
+    ["second", -2.0],
 ]
 
 [[units]]
@@ -1261,6 +1289,14 @@ name = "poise"
 dimension = "cgs_dynamic_viscosity"
 aliases = [
     "P",
+]
+
+[units.base_form]
+prefactor = 0.1
+factors = [
+    ["kilogram", 1.0],
+    ["meter", -1.0],
+    ["second", -1.0],
 ]
 
 [[units]]
@@ -1362,6 +1398,13 @@ name = "stokes"
 dimension = "cgs_kinematic_viscosity"
 aliases = [
     "St",
+]
+
+[units.base_form]
+prefactor = 0.0001
+factors = [
+    ["meter", 2.0],
+    ["second", -1.0],
 ]
 
 [[units]]
@@ -2156,6 +2199,14 @@ aliases = [
     "dyn",
 ]
 
+[units.base_form]
+prefactor = 1e-05
+factors = [
+    ["meter", 1.0],
+    ["kilogram", 1.0],
+    ["second", -2.0],
+]
+
 [[units]]
 name = "electron_volt"
 dimension = "natural_energy"
@@ -2190,6 +2241,14 @@ name = "erg"
 dimension = "cgs_energy"
 aliases = [
     "erg",
+]
+
+[units.base_form]
+prefactor = 1e-07
+factors = [
+    ["meter", 2.0],
+    ["kilogram", 1.0],
+    ["second", -2.0],
 ]
 
 [[units]]

--- a/ucon/core/_types.py
+++ b/ucon/core/_types.py
@@ -377,13 +377,28 @@ class BaseForm:
 
     Invariants:
         - ``prefactor`` is positive and finite
-        - ``factors`` references only base units of the unit's own basis
-        - dimensionally consistent with the parent Unit's ``dimension``
+        - ``factors`` references only canonical (SI) base units
+        - for SI-basis units, dimensionally consistent with the parent
+          Unit's ``dimension``; purely multiplicative CGS-mechanical
+          units (dyne, erg, poise, stokes, barye, galileo, kayser,
+          langley) carry their exact SI-equivalent factorization even
+          though their own ``dimension`` lives in the CGS basis
         - immutable; set at Unit construction; never mutated
 
-    Affine units (kelvin/celsius/fahrenheit) and logarithmic units (dB, Np)
-    cannot be represented as a single (prefactor, factors) pair and have
-    ``base_form = None``.
+    ``base_form = None`` means no single (prefactor, factors)
+    representation exists, for one of two reasons:
+
+    - **chart structure** — affine units (celsius, fahrenheit) have an
+      offset no pure scaling can express, and logarithmic units (dB, Np,
+      pH) are levels, not scalings;
+    - **cross-basis dimensional scoping** — electromagnetic CGS units
+      (gauss, maxwell, statvolt, abohm, …) have dimensional exponents
+      that genuinely differ from their SI counterparts', so an
+      SI factorization would be dimensionally ill-typed; conversion
+      routes through ``RebasedUnit`` edges instead.
+
+    Never infer a unit's chart/scale structure from ``base_form is
+    None`` alone — the two causes above are unrelated.
     """
     factors: tuple  # tuple[tuple[Unit, float], ...]
     prefactor: float = 1.0


### PR DESCRIPTION
Closes #283.

## Resolution: populate, don't document

`base_form is None` conflated three unrelated causes, and this PR makes `None` mean something again:

| Cause | Units | Disposition |
|---|---|---|
| Chart structure — no factorization exists | celsius, fahrenheit, dB, pH, … | stays `None` (correct) |
| Basis scoping — exact factorization exists, never recorded | **dyne, erg, poise, stokes, barye, galileo, kayser, langley** | **populated with exact SI values** |
| Cross-basis dimensional scoping | gauss, maxwell, statvolt, ab\*, … (EM CGS) | stays `None` **deliberately** — their dimensional exponents genuinely differ from SI's; conversion routes through `RebasedUnit` edges |
| Pseudo-dimension | degree | stays `None` until the 3.0.0 retirement |

Scope discovery during implementation: every CGS unit lives in its own `cgs_*` dimension, so the mechanical/EM split above is structural, not stylistic — only the purely multiplicative mechanical units have well-typed SI factorizations.

## Consumer audit — one live finding, fixed

The issue's second question ("which code paths consult `base_form`?") caught a real regression before it shipped: `enforce_dimensions`' cross-basis coercion has an algebraic path that fires when `base_form` exists — populating erg/poise made coercions return **anonymous products** (`''`) instead of named units (`joule`, `pascal_second`). Fixed by restructuring `_coerce_to_si`: SI-dimensioned units coerce algebraically as before; cross-basis units prefer the graph (named SI targets), with the algebraic decomposition retained as fallback for graphs that cannot reach SI. Both pre-existing behavioral contracts preserved.

Beneficiaries: the base-form conversion shortcut and #280's composite-path sibling links now cover mechanical CGS units.

## Contract documentation

The `BaseForm` docstring now states the full contract — including the forward-looking rule the chart work depends on: **never infer a unit's chart/scale structure from `base_form is None`** (the two remaining `None` causes are unrelated).

## Verification

- 26 new tests (`tests/ucon/test_cgs_base_forms.py`): exact values for the eight populated units, `None` pinned for sixteen EM CGS units and the affine/log set, dyne→newton conversion unchanged
- `base-forms-check` oracle: 143/143 agreed, 0 drifted
- Full suite: 3175 passed, 0 failed
- CHANGELOG entry under Unreleased (with the `[2.1.6]` re-sectioning folded into this PR's rebase, including a retroactive note on 2.1.6's parser-level duplicate rejection)
