### PR TITLE
hoists test imports to module top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Test suite: function-local imports hoisted to module top.** ~1,250
+  local import lines across 40 test files move to module scope per the
+  no-local-imports rule; `integrations/` keeps its module-level
+  try/except optional-dependency guards; two genuinely distinct private
+  helpers (`_get_numpy` in `core._types` vs `maps`) hoist under aliases.
+  No behavior change (suite results identical before/after).
 - **v2.2.0 delivers the aspect stratum; package infrastructure moves
   to v2.3.0.** Release reassignment per
   [decisions/008](docs/internal/decisions/008-aspect-stratum.md) and

--- a/tests/ucon/aspects/test_aspect_set.py
+++ b/tests/ucon/aspects/test_aspect_set.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pytest
 
 from ucon.aspects import AspectSet
+from ucon.aspects import join_aspects
 
 
 def test_aspect_set_literal_is_a_frozenset():
@@ -132,7 +133,6 @@ def test_aspect_set_set_algebra_returns_frozenset():
 
 def test_aspect_set_subclass_compatible_with_internal_signatures():
     # An AspectSet must drop into any place that expects frozenset[str].
-    from ucon.aspects import join_aspects
 
     a = AspectSet("calibrated", "ICRP103")
     b = AspectSet("calibrated", "smoothed")

--- a/tests/ucon/basis/test_basis.py
+++ b/tests/ucon/basis/test_basis.py
@@ -11,6 +11,9 @@ from ucon.basis import Basis, BasisComponent, BasisTransform, Vector
 from ucon.basis import ops
 from ucon.basis.graph import BasisGraph
 from ucon.system import active_system, use
+from ucon.basis import BasisGraph
+from ucon.basis import BasisGraph, NoTransformPath
+from ucon.basis import LossyProjection
 
 
 # -----------------------------------------------------------------------------
@@ -469,7 +472,6 @@ class TestVectorCrossBasisArithmetic:
     @pytest.fixture
     def graph_with_embedding(self, si_to_economic):
         """A BasisGraph carrying only the SI -> economic embedding."""
-        from ucon.basis.graph import BasisGraph
         graph = BasisGraph()
         graph.add_transform(si_to_economic)
         return graph
@@ -670,7 +672,6 @@ class TestBasisTransform:
 
     def test_lossy_projection_raises(self, si_basis, si_to_cgs):
         """GIVEN a vector with non-zero dropped component, THEN LossyProjection raised."""
-        from ucon.basis import LossyProjection
 
         # SI current: I^1
         si_current = Vector(si_basis, (Fraction(0), Fraction(0), Fraction(0), Fraction(1)))
@@ -997,14 +998,12 @@ class TestBasisGraph:
 
     def test_empty_graph(self):
         """GIVEN a new graph, THEN it has no transforms."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         assert "0 bases" in repr(graph)
 
     def test_add_transform(self, si_basis, cgs_basis, si_to_cgs):
         """GIVEN a transform, THEN it is registered."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         graph.add_transform(si_to_cgs)
@@ -1014,7 +1013,6 @@ class TestBasisGraph:
 
     def test_get_transform_identity(self, si_basis):
         """GIVEN same source and target, THEN identity returned."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         transform = graph.get_transform(si_basis, si_basis)
@@ -1023,7 +1021,6 @@ class TestBasisGraph:
 
     def test_get_transform_no_path(self, si_basis, game_basis):
         """GIVEN no path between bases, THEN NoTransformPath raised."""
-        from ucon.basis import BasisGraph, NoTransformPath
 
         graph = BasisGraph()
 
@@ -1038,7 +1035,6 @@ class TestBasisGraph:
         self, si_basis, cgs_basis, cgs_esu_basis, si_to_cgs, cgs_to_cgs_esu
     ):
         """GIVEN SI->CGS and CGS->CGS-ESU, THEN SI->CGS-ESU is composed."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         graph.add_transform(si_to_cgs)
@@ -1059,7 +1055,6 @@ class TestBasisGraph:
 
     def test_caching(self, si_basis, cgs_basis, cgs_esu_basis, si_to_cgs, cgs_to_cgs_esu):
         """GIVEN transitive path, THEN composed transform is cached."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         graph.add_transform(si_to_cgs)
@@ -1072,7 +1067,6 @@ class TestBasisGraph:
 
     def test_cache_invalidation(self, si_basis, cgs_basis, si_to_cgs):
         """GIVEN a cached transform, WHEN new transform added, THEN cache cleared."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         graph.add_transform(si_to_cgs)
@@ -1088,7 +1082,6 @@ class TestBasisGraph:
 
     def test_are_connected(self, si_basis, cgs_basis, game_basis, si_to_cgs):
         """GIVEN a graph, THEN are_connected returns correct results."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         graph.add_transform(si_to_cgs)
@@ -1101,7 +1094,6 @@ class TestBasisGraph:
         self, si_basis, cgs_basis, cgs_esu_basis, game_basis, si_to_cgs, cgs_to_cgs_esu
     ):
         """GIVEN a graph, THEN reachable_from returns all connected bases."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
         graph.add_transform(si_to_cgs)
@@ -1116,7 +1108,6 @@ class TestBasisGraph:
 
     def test_with_transform(self, si_basis, cgs_basis, game_basis, si_to_cgs):
         """GIVEN a graph, THEN with_transform returns new graph (copy-on-extend)."""
-        from ucon.basis import BasisGraph
 
         base_graph = BasisGraph()
         base_graph.add_transform(si_to_cgs)
@@ -1142,7 +1133,6 @@ class TestBasisGraph:
 
     def test_add_transform_pair(self, cgs_basis):
         """GIVEN forward and reverse transforms, THEN both registered."""
-        from ucon.basis import BasisGraph
 
         graph = BasisGraph()
 

--- a/tests/ucon/basis/test_cross_basis.py
+++ b/tests/ucon/basis/test_cross_basis.py
@@ -57,6 +57,8 @@ from ucon.dimension import (
     DYNAMIC_VISCOSITY,
     KINEMATIC_VISCOSITY,
 )
+from ucon.core import UnitProduct
+from ucon.core import UnitProduct, UnitFactor, Scale
 
 
 class TestCGSDimensionIsolation(unittest.TestCase):
@@ -451,28 +453,24 @@ class TestCrossBasisProductFallback(unittest.TestCase):
         self.graph = get_default_graph()
 
     def test_poise_product_to_pascal_second_product(self):
-        from ucon.core import UnitProduct, UnitFactor, Scale
         src = UnitProduct.from_unit(units.poise)
         dst = UnitProduct({UnitFactor(units.pascal_second, Scale.one): 1})
         m = self.graph.convert(src=src, dst=dst)
         self.assertAlmostEqual(m(1), 0.1, places=5)
 
     def test_stokes_product_to_square_meter_per_second_product(self):
-        from ucon.core import UnitProduct
         src = UnitProduct.from_unit(units.stokes)
         dst = UnitProduct.from_unit(units.square_meter_per_second)
         m = self.graph.convert(src=src, dst=dst)
         self.assertAlmostEqual(m(1), 1e-4, places=9)
 
     def test_galileo_product_to_meter_per_second_squared_product(self):
-        from ucon.core import UnitProduct
         src = UnitProduct.from_unit(units.galileo)
         dst = UnitProduct.from_unit(units.meter_per_second_squared)
         m = self.graph.convert(src=src, dst=dst)
         self.assertAlmostEqual(m(1), 0.01, places=5)
 
     def test_reyn_product_to_pascal_second_product(self):
-        from ucon.core import UnitProduct
         src = UnitProduct.from_unit(units.reyn)
         dst = UnitProduct.from_unit(units.pascal_second)
         m = self.graph.convert(src=src, dst=dst)
@@ -515,17 +513,14 @@ class TestUnitProductAsUnit(unittest.TestCase):
     """UnitProduct.as_unit() extraction."""
 
     def test_trivial_product_returns_unit(self):
-        from ucon.core import UnitProduct
         prod = UnitProduct.from_unit(units.meter)
         self.assertEqual(prod.as_unit(), units.meter)
 
     def test_scaled_product_returns_none(self):
-        from ucon.core import UnitProduct, UnitFactor, Scale
         prod = UnitProduct({UnitFactor(units.meter, Scale.kilo): 1})
         self.assertIsNone(prod.as_unit())
 
     def test_multi_factor_product_returns_none(self):
-        from ucon.core import UnitProduct, UnitFactor, Scale
         prod = UnitProduct({
             UnitFactor(units.meter, Scale.one): 1,
             UnitFactor(units.second, Scale.one): -1,
@@ -533,7 +528,6 @@ class TestUnitProductAsUnit(unittest.TestCase):
         self.assertIsNone(prod.as_unit())
 
     def test_exponent_product_returns_none(self):
-        from ucon.core import UnitProduct, UnitFactor, Scale
         prod = UnitProduct({UnitFactor(units.meter, Scale.one): 2})
         self.assertIsNone(prod.as_unit())
 

--- a/tests/ucon/basis/test_graph_basis_transform.py
+++ b/tests/ucon/basis/test_graph_basis_transform.py
@@ -18,6 +18,11 @@ from ucon.graph import ConversionGraph
 from ucon.maps import LinearMap
 from ucon import Dimension, units
 from ucon.basis.builtin import SI
+from ucon.basis import BasisGraph
+from ucon.basis import BasisGraph, BasisTransform
+from ucon.basis.builtin import SI, CGS
+from ucon.basis.transforms import SI_TO_CGS
+from ucon.graph import DimensionMismatch
 
 
 class TestGraphAddEdgeWithBasisTransform(unittest.TestCase):
@@ -165,15 +170,11 @@ class TestUnitIsCompatible(unittest.TestCase):
 
     def test_different_dimension_same_basis_incompatible_with_graph(self):
         # Even with BasisGraph, different dimensions in same basis are incompatible
-        from ucon.basis import BasisGraph
         bg = BasisGraph()
         self.assertFalse(units.meter.is_compatible(units.second, basis_graph=bg))
 
     def test_cross_basis_compatible_when_connected(self):
         # Create two connected bases
-        from ucon.basis import BasisGraph, BasisTransform
-        from ucon.basis.builtin import SI, CGS
-        from ucon.basis.transforms import SI_TO_CGS
 
         bg = BasisGraph()
         bg = bg.with_transform(SI_TO_CGS)
@@ -190,14 +191,11 @@ class TestConvertBasisGraphValidation(unittest.TestCase):
     """Test convert() dimensional validation via BasisGraph."""
 
     def test_dimension_mismatch_without_basis_graph(self):
-        from ucon.graph import DimensionMismatch
         graph = ConversionGraph()
         with self.assertRaises(DimensionMismatch):
             graph.convert(src=units.meter, dst=units.second)
 
     def test_dimension_mismatch_with_basis_graph_same_basis(self):
-        from ucon.graph import DimensionMismatch
-        from ucon.basis import BasisGraph
         bg = BasisGraph()
         graph = ConversionGraph()
         graph._basis_graph = bg

--- a/tests/ucon/basis/test_vector_strict_basis.py
+++ b/tests/ucon/basis/test_vector_strict_basis.py
@@ -20,6 +20,7 @@ import pytest
 
 from ucon.basis import Basis, BasisComponent, BasisMismatch, Vector
 from ucon.basis.builtin import SI
+import ucon.basis.vector as vector_module
 
 
 def _vec(basis: Basis, **named: int) -> Vector:
@@ -85,7 +86,6 @@ class TestVectorImportSurface:
     """``vector.py`` must not reach the graph layer."""
 
     def test_vector_module_does_not_expose_basis_graph(self) -> None:
-        import ucon.basis.vector as vector_module
 
         attrs = dir(vector_module)
         assert "BasisGraph" not in attrs

--- a/tests/ucon/conversion/test_composite_endpoints.py
+++ b/tests/ucon/conversion/test_composite_endpoints.py
@@ -29,6 +29,7 @@ from ucon.graph import (
 )
 from ucon.maps import LinearMap
 from ucon.resolver import parse_unit
+from ucon.graph import DimensionMismatch
 
 US_GALLON_M3 = 0.003785411784  # 231 in³, exact
 
@@ -97,7 +98,6 @@ class TestCompositeEndpointPaths(unittest.TestCase):
     def test_dimension_mismatch_not_swallowed_by_fallback(self):
         """The fallback fires only on ConversionNotFound; dimension errors
         propagate untouched."""
-        from ucon.graph import DimensionMismatch
         with using_conversion_graph(self.graph):
             with self.assertRaises(DimensionMismatch):
                 self.graph.convert(src=self.gallon, dst=units.kilogram)

--- a/tests/ucon/conversion/test_default_graph_conversions.py
+++ b/tests/ucon/conversion/test_default_graph_conversions.py
@@ -14,6 +14,7 @@ These tests verify that Number.to() works correctly with the default graph for:
 import unittest
 
 from ucon import units
+from ucon.core import Scale
 
 
 class TestTemperatureConversions(unittest.TestCase):
@@ -377,7 +378,6 @@ class TestInformationConversions(unittest.TestCase):
 
     def test_kilobyte_to_bit(self):
         """1 KB = 8000 b (using Scale.kilo)"""
-        from ucon.core import Scale
         kilobyte = Scale.kilo * units.byte
         result = kilobyte(1).to(units.bit)
         self.assertAlmostEqual(result.quantity, 8000, places=0)

--- a/tests/ucon/conversion/test_graph.py
+++ b/tests/ucon/conversion/test_graph.py
@@ -15,6 +15,7 @@ from ucon.graph import (
     using_conversion_graph,
 )
 from ucon.maps import LinearMap, AffineMap
+from ucon import active
 
 
 class TestConversionGraphEdgeManagement(unittest.TestCase):
@@ -404,7 +405,6 @@ class TestGetDefaultGraphTierFallthrough(unittest.TestCase):
         ``ctx.system.conversion_graph`` rather than treated as a
         ``UnitSystem`` directly.
         """
-        from ucon import active
         ctx = active()
         # Sanity: payload is the ActiveContext bundle, not a UnitSystem.
         self.assertFalse(hasattr(ctx, "conversion_graph"))

--- a/tests/ucon/conversion/test_graph_coverage.py
+++ b/tests/ucon/conversion/test_graph_coverage.py
@@ -37,6 +37,17 @@ from ucon.graph import (
     using_conversion_graph,
 )
 from ucon.maps import LinearMap, AffineMap, Map
+from ucon.basis import NoTransformPath
+from ucon.constants import Constant
+from ucon.contexts import ConversionContext, ContextEdge
+from ucon.contexts import spectroscopy, using_context
+from ucon.kinds import Kind, KindLattice
+from ucon.maps import ComposedMap
+from ucon.maps import LogMap
+from ucon.packages import EdgeDef
+from ucon.packages import UnitPackage, EdgeDef
+from ucon.packages import UnitPackage, PackageLoadError
+from ucon.packages import UnitPackage, UnitDef, EdgeDef
 
 
 # -----------------------------------------------------------------------
@@ -47,7 +58,6 @@ class TestAddEdgeBasisGraphValidation(unittest.TestCase):
     """add_edge raises NoTransformPath when basis_graph rejects unconnected bases."""
 
     def test_disconnected_bases_raise_no_transform_path(self):
-        from ucon.basis import NoTransformPath
 
         # Create two disconnected bases
         comp_a = BasisComponent("X", "X")
@@ -155,7 +165,6 @@ class TestCrossDimensionalBFS(unittest.TestCase):
     """Cross-dimensional BFS finds path through context edges."""
 
     def test_cross_dimensional_path_via_context(self):
-        from ucon.contexts import spectroscopy, using_context
         # spectroscopy context adds meter→hertz (cross-dimensional)
         with using_context(spectroscopy):
             graph = get_default_graph()
@@ -453,7 +462,6 @@ class TestWithPackage(unittest.TestCase):
     """with_package loads units, edges, and constants from a UnitPackage."""
 
     def test_with_package_basic(self):
-        from ucon.packages import UnitPackage, UnitDef, EdgeDef
 
         pkg = UnitPackage(
             name="test_pkg",
@@ -485,7 +493,6 @@ class TestWithPackage(unittest.TestCase):
         self.assertIn("test_pkg", extended._loaded_packages)
 
     def test_with_package_missing_requires(self):
-        from ucon.packages import UnitPackage, PackageLoadError
 
         pkg = UnitPackage(
             name="dependent_pkg",
@@ -502,7 +509,6 @@ class TestWithPackage(unittest.TestCase):
         self.assertIn("nonexistent_pkg", str(ctx.exception))
 
     def test_package_edge_already_covered_skips(self):
-        from ucon.packages import UnitPackage, EdgeDef
 
         # meter→foot already exists in the default graph
         pkg = UnitPackage(
@@ -522,7 +528,6 @@ class TestWithPackage(unittest.TestCase):
         self.assertIn("redundant_pkg", extended._loaded_packages)
 
     def test_package_edge_unresolvable_unit_not_covered(self):
-        from ucon.packages import EdgeDef
 
         # Edge referencing a unit that doesn't exist in the graph
         edge_def = EdgeDef(src="nonexistent_src", dst="nonexistent_dst", factor=1.0)
@@ -874,7 +879,6 @@ class _StubMap(Map):
         return self
 
     def __matmul__(self, other):
-        from ucon.maps import ComposedMap
         return ComposedMap(outer=self, inner=other)
 
     def __pow__(self, n):
@@ -901,7 +905,6 @@ class TestMapsEqualFallbacks(unittest.TestCase):
 
     def test_fallback_to_second_try_block(self):
         """Lines 1032, 1034: first try raises at 0.0, second try succeeds."""
-        from ucon.maps import LogMap
         # LogMap raises ValueError at x=0.0 (log(0) is undefined).
         m1 = LogMap(scale=10)  # 10 * log10(x)
         m2 = LogMap(scale=20)  # 20 * log10(x)
@@ -912,7 +915,6 @@ class TestMapsEqualFallbacks(unittest.TestCase):
 
     def test_fallback_second_try_equal(self):
         """Second try block returns True when maps agree at 1.0 and 2.0."""
-        from ucon.maps import LogMap
         m1 = LogMap(scale=10)
         m2 = LogMap(scale=10)  # identical
         # First try raises at 0.0, second try checks 1.0 and 2.0 → agree → True
@@ -1118,7 +1120,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_constants_length_mismatch(self):
         """Line 1107: different number of constants."""
-        from ucon.constants import Constant
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         c = Constant(
@@ -1131,7 +1132,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_constants_field_mismatch(self):
         """Line 1113: same number of constants but different fields."""
-        from ucon.constants import Constant
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         c1 = Constant(
@@ -1150,7 +1150,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_constants_unit_dimension_mismatch(self):
         """Line 1116: constants have same fields but different unit dimensions."""
-        from ucon.constants import Constant
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         c1 = Constant(
@@ -1359,7 +1358,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_context_key_mismatch(self):
         """Line 1188: different context names."""
-        from ucon.contexts import ConversionContext, ContextEdge
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         ctx = ConversionContext(
@@ -1374,7 +1372,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_context_description_mismatch(self):
         """Line 1192: same context name but different descriptions."""
-        from ucon.contexts import ConversionContext, ContextEdge
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         edge = ContextEdge(src=units.meter, dst=units.hertz, map=LinearMap(299792458))
@@ -1386,7 +1383,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_context_edge_count_mismatch(self):
         """Line 1194: same context name but different number of edges."""
-        from ucon.contexts import ConversionContext, ContextEdge
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         edge1 = ContextEdge(src=units.meter, dst=units.hertz, map=LinearMap(299792458))
@@ -1399,7 +1395,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_context_edge_src_mismatch(self):
         """Line 1197: same context structure but different edge source."""
-        from ucon.contexts import ConversionContext, ContextEdge
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         edge1 = ContextEdge(src=units.meter, dst=units.hertz, map=LinearMap(299792458))
@@ -1412,7 +1407,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_context_edge_dst_mismatch(self):
         """Line 1199: same context structure but different edge destination."""
-        from ucon.contexts import ConversionContext, ContextEdge
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         edge1 = ContextEdge(src=units.meter, dst=units.hertz, map=LinearMap(299792458))
@@ -1425,7 +1419,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_context_edge_map_mismatch(self):
         """Line 1201: same context structure but different edge map."""
-        from ucon.contexts import ConversionContext, ContextEdge
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         edge1 = ContextEdge(src=units.meter, dst=units.hertz, map=LinearMap(299792458))
@@ -1444,7 +1437,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_kind_lattice_asymmetric_none(self):
         """Line 1403: one graph has kind lattice, the other does not."""
-        from ucon.kinds import Kind, KindLattice
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         lattice = KindLattice([Kind("energy", dimension=Dimension.energy)])
@@ -1454,7 +1446,6 @@ class TestGraphEquality(unittest.TestCase):
 
     def test_kind_lattice_name_mismatch(self):
         """Line 1406: both graphs have kind lattices with different names."""
-        from ucon.kinds import Kind, KindLattice
         g1 = self._make_minimal_graph()
         g2 = self._make_minimal_graph()
         g1._kind_lattice = KindLattice([Kind("energy", dimension=Dimension.energy)])

--- a/tests/ucon/conversion/test_logarithmic.py
+++ b/tests/ucon/conversion/test_logarithmic.py
@@ -14,6 +14,7 @@ import pytest
 
 from ucon import units
 from ucon.maps import LogMap, ExpMap
+from ucon.core import Scale
 
 
 class TestLogMapReference:
@@ -161,7 +162,6 @@ class TestLogarithmicConversions:
 
     def test_milliwatt_to_dbm_via_watt(self):
         """1 mW = 0 dBm (via watt conversion)"""
-        from ucon.core import Scale
         # milliwatt = gram with milli scale, but we need to use watt with milli scale
         milliwatt = units.watt(1e-3)  # 1 mW as 0.001 W
         dbm = milliwatt.to(units.decibel_milliwatt)

--- a/tests/ucon/integrations/test_numpy.py
+++ b/tests/ucon/integrations/test_numpy.py
@@ -12,6 +12,23 @@ try:
     HAS_NUMPY = True
 except ImportError:
     HAS_NUMPY = False
+from ucon import units
+from ucon.core import Scale
+from ucon.core import UnitProduct
+from ucon.core._types import _scale_factor_cache
+from ucon.dimension import Dimension
+from ucon.integrations.numpy import NumberArray
+from ucon.maps import AffineMap
+from ucon.maps import ExpMap
+from ucon.maps import LinearMap
+from ucon.maps import LogMap
+from ucon.quantity import Number
+from fractions import Fraction
+from ucon.core._types import (
+    _parsing_graph,
+    _scale_factor_cache,
+    _sys_active_var,
+)
 
 
 @unittest.skipUnless(HAS_NUMPY, "NumPy not installed")
@@ -19,48 +36,40 @@ class TestNumberArrayBasic(unittest.TestCase):
     """Test NumberArray construction and basic properties."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.foot = units.foot
         self.second = units.second
 
     def test_create_from_list(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         self.assertEqual(len(arr), 3)
         self.assertEqual(arr.shape, (3,))
         self.assertEqual(arr.unit, self.meter)
 
     def test_create_from_ndarray(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray(np.array([1.0, 2.0, 3.0]), unit=self.meter)
         self.assertEqual(len(arr), 3)
         np.testing.assert_array_equal(arr.quantities, np.array([1.0, 2.0, 3.0]))
 
     def test_default_unit_is_dimensionless(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0])
         self.assertEqual(arr.unit, UnitProduct({}))
 
     def test_uniform_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter, uncertainty=0.1)
         self.assertEqual(arr.uncertainty, 0.1)
 
     def test_per_element_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         unc = [0.1, 0.2, 0.3]
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter, uncertainty=unc)
         np.testing.assert_array_equal(arr.uncertainty, np.array(unc))
 
     def test_uncertainty_shape_mismatch_raises(self):
-        from ucon.integrations.numpy import NumberArray
         with self.assertRaises(ValueError) as ctx:
             NumberArray([1.0, 2.0, 3.0], unit=self.meter, uncertainty=[0.1, 0.2])
         self.assertIn("shape", str(ctx.exception))
 
     def test_ndim_property(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         self.assertEqual(arr.ndim, 1)
 
@@ -68,7 +77,6 @@ class TestNumberArrayBasic(unittest.TestCase):
         self.assertEqual(arr_2d.ndim, 2)
 
     def test_dtype_property(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1, 2, 3], unit=self.meter)
         self.assertEqual(arr.dtype, np.float64)
 
@@ -78,12 +86,9 @@ class TestNumberArrayIndexing(unittest.TestCase):
     """Test NumberArray indexing and iteration."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_scalar_index_returns_number(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         elem = arr[0]
         self.assertIsInstance(elem, Number)
@@ -91,7 +96,6 @@ class TestNumberArrayIndexing(unittest.TestCase):
         self.assertEqual(elem.unit, self.meter)
 
     def test_slice_returns_numberarray(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0, 4.0], unit=self.meter)
         sliced = arr[1:3]
         self.assertIsInstance(sliced, NumberArray)
@@ -99,20 +103,16 @@ class TestNumberArrayIndexing(unittest.TestCase):
         np.testing.assert_array_equal(sliced.quantities, np.array([2.0, 3.0]))
 
     def test_index_with_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         elem = arr[0]
         self.assertEqual(elem.uncertainty, 0.1)
 
     def test_index_with_per_element_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=[0.1, 0.2])
         self.assertEqual(arr[0].uncertainty, 0.1)
         self.assertEqual(arr[1].uncertainty, 0.2)
 
     def test_iteration_yields_numbers(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         elements = list(arr)
         self.assertEqual(len(elements), 3)
@@ -125,37 +125,31 @@ class TestNumberArrayArithmetic(unittest.TestCase):
     """Test NumberArray arithmetic operations."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_multiply_by_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr * 2
         np.testing.assert_array_equal(result.quantities, np.array([2.0, 4.0, 6.0]))
         self.assertEqual(result.unit, self.meter)
 
     def test_multiply_by_scalar_with_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         result = arr * 2
         self.assertEqual(result.uncertainty, 0.2)
 
     def test_rmul(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = 2 * arr
         np.testing.assert_array_equal(result.quantities, np.array([2.0, 4.0, 6.0]))
 
     def test_divide_by_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([2.0, 4.0, 6.0], unit=self.meter)
         result = arr / 2
         np.testing.assert_array_equal(result.quantities, np.array([1.0, 2.0, 3.0]))
 
     def test_multiply_numberarrays(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter)
         b = NumberArray([3.0, 4.0], unit=self.second)
         result = a * b
@@ -165,7 +159,6 @@ class TestNumberArrayArithmetic(unittest.TestCase):
         self.assertIn('s', str(result.unit))
 
     def test_multiply_numberarrays_incompatible_shapes(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([1.0, 2.0], unit=self.meter)
         with self.assertRaises(ValueError) as ctx:
@@ -173,14 +166,12 @@ class TestNumberArrayArithmetic(unittest.TestCase):
         self.assertIn("not broadcast-compatible", str(ctx.exception))
 
     def test_add_same_unit(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter)
         b = NumberArray([0.5, 0.5], unit=self.meter)
         result = a + b
         np.testing.assert_array_equal(result.quantities, np.array([1.5, 2.5]))
 
     def test_add_different_unit_raises(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter)
         b = NumberArray([1.0, 2.0], unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -188,20 +179,17 @@ class TestNumberArrayArithmetic(unittest.TestCase):
         self.assertIn("different units", str(ctx.exception))
 
     def test_subtract(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([3.0, 4.0], unit=self.meter)
         b = NumberArray([1.0, 1.0], unit=self.meter)
         result = a - b
         np.testing.assert_array_equal(result.quantities, np.array([2.0, 3.0]))
 
     def test_negation(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, -2.0, 3.0], unit=self.meter)
         result = -arr
         np.testing.assert_array_equal(result.quantities, np.array([-1.0, 2.0, -3.0]))
 
     def test_abs(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([-1.0, 2.0, -3.0], unit=self.meter)
         result = abs(arr)
         np.testing.assert_array_equal(result.quantities, np.array([1.0, 2.0, 3.0]))
@@ -212,15 +200,12 @@ class TestNumberArrayConversion(unittest.TestCase):
     """Test NumberArray unit conversion."""
 
     def setUp(self):
-        from ucon import units
-        from ucon.core import Scale
         self.meter = units.meter
         self.foot = units.foot
         self.kilometer = Scale.kilo * units.meter
         self.centimeter = Scale.centi * units.meter
 
     def test_scale_only_conversion(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.kilometer)
         result = arr.to(self.meter)
         np.testing.assert_array_almost_equal(
@@ -229,14 +214,12 @@ class TestNumberArrayConversion(unittest.TestCase):
         self.assertEqual(result.unit, self.meter)
 
     def test_conversion_with_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.kilometer, uncertainty=0.1)
         result = arr.to(self.meter)
         # Uncertainty should scale by same factor
         self.assertAlmostEqual(result.uncertainty, 100.0)
 
     def test_graph_based_conversion(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr.to(self.foot)
         # 1 meter ≈ 3.28084 feet
@@ -245,9 +228,6 @@ class TestNumberArrayConversion(unittest.TestCase):
 
     def test_is_scale_only_conversion_factor_count_mismatch(self):
         """Different factor counts return False (length-mismatch fast path)."""
-        from ucon import units
-        from ucon.core import UnitProduct
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0], unit=self.meter)
         src = UnitProduct.from_unit(self.meter)
         # Build a composite (meter * second) — 2 factors, vs src with 1.
@@ -256,9 +236,6 @@ class TestNumberArrayConversion(unittest.TestCase):
 
     def test_is_scale_only_conversion_dimension_mismatch(self):
         """Same factor count but different dimensions returns False."""
-        from ucon import units
-        from ucon.core import UnitProduct
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0], unit=self.meter)
         src = UnitProduct.from_unit(self.meter)
         dst = UnitProduct.from_unit(units.second)
@@ -266,7 +243,6 @@ class TestNumberArrayConversion(unittest.TestCase):
 
     def test_graph_based_conversion_with_uncertainty(self):
         """Covers uncertainty propagation through ``conversion_map.derivative``."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         result = arr.to(self.foot)
         # δ propagates by the conversion derivative (~3.28084).
@@ -277,8 +253,6 @@ class TestNumberArrayConversion(unittest.TestCase):
 
     def test_cache_hit_propagates_uncertainty(self):
         """Cache-hit fast path scales uncertainty by ``abs(factor)``."""
-        from ucon.core._types import _scale_factor_cache
-        from ucon.integrations.numpy import NumberArray
         # Seed the cache with a known factor so the next ``.to()`` call
         # exercises the cache-hit branch (including uncertainty scaling).
         cache_key = (self.meter, self.foot)
@@ -306,12 +280,6 @@ class TestNumberArrayConversion(unittest.TestCase):
         both the parsing-graph ContextVar and the active-system ContextVar
         hold ``None``, conversion has no graph to consult.
         """
-        from ucon.core._types import (
-            _parsing_graph,
-            _scale_factor_cache,
-            _sys_active_var,
-        )
-        from ucon.integrations.numpy import NumberArray
 
         arr = NumberArray([1.0], unit=self.meter)
         # Make sure the scale-only fast path can't satisfy the request and
@@ -336,12 +304,9 @@ class TestNumberArrayUncertaintyPropagation(unittest.TestCase):
     """Test uncertainty propagation through arithmetic."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_multiplication_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         # a = [10, 20] ± 1
         # b = 2 ± 0.1
         # For c = a * b:
@@ -356,7 +321,6 @@ class TestNumberArrayUncertaintyPropagation(unittest.TestCase):
         self.assertAlmostEqual(result.uncertainty[0], expected_unc_1, places=5)
 
     def test_addition_uncertainty_quadrature(self):
-        from ucon.integrations.numpy import NumberArray
         # δ(a+b) = sqrt(δa² + δb²)
         a = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         b = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.2)
@@ -368,7 +332,6 @@ class TestNumberArrayUncertaintyPropagation(unittest.TestCase):
 
     def test_addition_uncertainty_only_on_left(self):
         """``δa + None`` propagates ``δa`` through (covers None-ub branch)."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         b = NumberArray([1.0, 2.0], unit=self.meter)  # no uncertainty
         result = a + b
@@ -378,7 +341,6 @@ class TestNumberArrayUncertaintyPropagation(unittest.TestCase):
 
     def test_addition_uncertainty_only_on_right(self):
         """``None + δb`` propagates ``δb`` through (covers None-ua branch)."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter)  # no uncertainty
         b = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.2)
         result = a + b
@@ -388,8 +350,6 @@ class TestNumberArrayUncertaintyPropagation(unittest.TestCase):
 
     def test_multiplication_uncertainty_only_on_left(self):
         """``δa * None`` covers the ``rel_b = zeros_like`` branch."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([10.0, 20.0], unit=self.meter, uncertainty=1.0)
         scalar = Number(quantity=2.0, unit=self.meter)  # no uncertainty
         result = arr * scalar
@@ -400,8 +360,6 @@ class TestNumberArrayUncertaintyPropagation(unittest.TestCase):
 
     def test_multiplication_uncertainty_only_on_right(self):
         """``None * δb`` covers the ``rel_a = zeros_like`` branch."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([10.0, 20.0], unit=self.meter)  # no uncertainty
         scalar = Number(quantity=2.0, unit=self.meter, uncertainty=0.1)
         result = arr * scalar
@@ -416,36 +374,30 @@ class TestCallableSyntax(unittest.TestCase):
     """Test unit callable syntax with arrays."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_unit_callable_with_list(self):
-        from ucon.integrations.numpy import NumberArray
         arr = self.meter([1.0, 2.0, 3.0])
         self.assertIsInstance(arr, NumberArray)
         self.assertEqual(len(arr), 3)
         self.assertEqual(arr.unit, self.meter)
 
     def test_unit_callable_with_ndarray(self):
-        from ucon.integrations.numpy import NumberArray
         arr = self.meter(np.array([1.0, 2.0, 3.0]))
         self.assertIsInstance(arr, NumberArray)
 
     def test_unit_callable_scalar_still_returns_number(self):
-        from ucon.quantity import Number
         n = self.meter(5.0)
         self.assertIsInstance(n, Number)
 
     def test_unitproduct_callable_with_list(self):
-        from ucon.integrations.numpy import NumberArray
         velocity_unit = self.meter / self.second
         arr = velocity_unit([10, 20, 30])
         self.assertIsInstance(arr, NumberArray)
         self.assertEqual(len(arr), 3)
 
     def test_unit_callable_with_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = self.meter([1.0, 2.0, 3.0], uncertainty=0.1)
         self.assertIsInstance(arr, NumberArray)
         self.assertEqual(arr.uncertainty, 0.1)
@@ -456,35 +408,30 @@ class TestMapArraySupport(unittest.TestCase):
     """Test that Maps work with array inputs."""
 
     def test_linearmap_with_array(self):
-        from ucon.maps import LinearMap
         m = LinearMap(2.0)
         arr = np.array([1.0, 2.0, 3.0])
         result = m(arr)
         np.testing.assert_array_equal(result, np.array([2.0, 4.0, 6.0]))
 
     def test_affinemap_with_array(self):
-        from ucon.maps import AffineMap
         m = AffineMap(2.0, 10.0)  # y = 2*x + 10
         arr = np.array([0.0, 5.0, 10.0])
         result = m(arr)
         np.testing.assert_array_equal(result, np.array([10.0, 20.0, 30.0]))
 
     def test_logmap_with_array(self):
-        from ucon.maps import LogMap
         m = LogMap(scale=10, base=10)  # 10 * log10(x) - dB power
         arr = np.array([1.0, 10.0, 100.0])
         result = m(arr)
         np.testing.assert_array_almost_equal(result, np.array([0.0, 10.0, 20.0]))
 
     def test_expmap_with_array(self):
-        from ucon.maps import ExpMap
         m = ExpMap(scale=0.1, base=10)  # 10^(0.1*x) - inverse of dB
         arr = np.array([0.0, 10.0, 20.0])
         result = m(arr)
         np.testing.assert_array_almost_equal(result, np.array([1.0, 10.0, 100.0]))
 
     def test_linearmap_derivative_with_array(self):
-        from ucon.maps import LinearMap
         m = LinearMap(2.0)
         arr = np.array([1.0, 2.0, 3.0])
         deriv = m.derivative(arr)
@@ -492,7 +439,6 @@ class TestMapArraySupport(unittest.TestCase):
         self.assertEqual(deriv, 2.0)
 
     def test_logmap_derivative_with_array(self):
-        from ucon.maps import LogMap
         m = LogMap(scale=10, base=10)
         arr = np.array([1.0, 10.0, 100.0])
         deriv = m.derivative(arr)
@@ -506,128 +452,102 @@ class TestNumberArrayComparison(unittest.TestCase):
     """Test comparison operators returning boolean arrays."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_eq_with_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr == 2.0
         np.testing.assert_array_equal(result, np.array([False, True, False]))
 
     def test_eq_with_number(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         result = arr == n
         np.testing.assert_array_equal(result, np.array([False, True, False]))
 
     def test_eq_with_numberarray(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([1.0, 5.0, 3.0], unit=self.meter)
         result = a == b
         np.testing.assert_array_equal(result, np.array([True, False, True]))
 
     def test_ne_with_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr != 2.0
         np.testing.assert_array_equal(result, np.array([True, False, True]))
 
     def test_lt_with_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr < 2.0
         np.testing.assert_array_equal(result, np.array([True, False, False]))
 
     def test_le_with_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr <= 2.0
         np.testing.assert_array_equal(result, np.array([True, True, False]))
 
     def test_gt_with_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr > 2.0
         np.testing.assert_array_equal(result, np.array([False, False, True]))
 
     def test_ge_with_scalar(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = arr >= 2.0
         np.testing.assert_array_equal(result, np.array([False, True, True]))
 
     def test_ne_with_number(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         np.testing.assert_array_equal(arr != n, np.array([True, False, True]))
 
     def test_ne_with_numberarray(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([1.0, 5.0, 3.0], unit=self.meter)
         np.testing.assert_array_equal(a != b, np.array([False, True, False]))
 
     def test_lt_with_number(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         np.testing.assert_array_equal(arr < n, np.array([True, False, False]))
 
     def test_lt_with_numberarray(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([2.0, 2.0, 2.0], unit=self.meter)
         np.testing.assert_array_equal(a < b, np.array([True, False, False]))
 
     def test_le_with_number(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         np.testing.assert_array_equal(arr <= n, np.array([True, True, False]))
 
     def test_le_with_numberarray(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([2.0, 2.0, 2.0], unit=self.meter)
         np.testing.assert_array_equal(a <= b, np.array([True, True, False]))
 
     def test_gt_with_number(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         np.testing.assert_array_equal(arr > n, np.array([False, False, True]))
 
     def test_gt_with_numberarray(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([2.0, 2.0, 2.0], unit=self.meter)
         np.testing.assert_array_equal(a > b, np.array([False, False, True]))
 
     def test_ge_with_number(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         np.testing.assert_array_equal(arr >= n, np.array([False, True, True]))
 
     def test_ge_with_numberarray(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([2.0, 2.0, 2.0], unit=self.meter)
         np.testing.assert_array_equal(a >= b, np.array([False, True, True]))
 
     def test_comparison_returns_notimplemented_for_unsupported_type(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.meter)
         self.assertEqual(arr.__ne__("string"), NotImplemented)
         self.assertEqual(arr.__lt__("string"), NotImplemented)
@@ -636,7 +556,6 @@ class TestNumberArrayComparison(unittest.TestCase):
         self.assertEqual(arr.__ge__("string"), NotImplemented)
 
     def test_comparison_different_unit_raises(self):
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter)
         b = NumberArray([1.0, 2.0], unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -644,7 +563,6 @@ class TestNumberArrayComparison(unittest.TestCase):
         self.assertIn("different units", str(ctx.exception))
 
     def test_comparison_for_filtering(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0, 4.0, 5.0], unit=self.meter)
         mask = arr > 2.5
         filtered = arr.quantities[mask]
@@ -656,12 +574,10 @@ class TestNumberArrayBroadcasting(unittest.TestCase):
     """Test numpy broadcasting support."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_mul_broadcasting_1d_scalar_array(self):
         """Test (3,) * (1,) broadcasting."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)  # shape (3,)
         b = NumberArray([2.0], unit=self.meter)  # shape (1,)
         result = a * b
@@ -669,7 +585,6 @@ class TestNumberArrayBroadcasting(unittest.TestCase):
 
     def test_mul_broadcasting_2d_1d(self):
         """Test (2, 3) * (3,) broadcasting."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([[1, 2, 3], [4, 5, 6]], unit=self.meter)  # shape (2, 3)
         b = NumberArray([1, 2, 3], unit=self.meter)  # shape (3,)
         result = a * b
@@ -678,7 +593,6 @@ class TestNumberArrayBroadcasting(unittest.TestCase):
 
     def test_add_broadcasting_2d_1d(self):
         """Test (2, 3) + (3,) broadcasting."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([[1, 2, 3], [4, 5, 6]], unit=self.meter)  # shape (2, 3)
         b = NumberArray([10, 20, 30], unit=self.meter)  # shape (3,)
         result = a + b
@@ -687,7 +601,6 @@ class TestNumberArrayBroadcasting(unittest.TestCase):
 
     def test_sub_broadcasting(self):
         """Test (3,) - (1,) broadcasting."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([10.0, 20.0, 30.0], unit=self.meter)
         b = NumberArray([5.0], unit=self.meter)
         result = a - b
@@ -695,7 +608,6 @@ class TestNumberArrayBroadcasting(unittest.TestCase):
 
     def test_div_broadcasting(self):
         """Test (2, 2) / (2,) broadcasting."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([[4, 6], [8, 10]], unit=self.meter)
         b = NumberArray([2, 2], unit=self.meter)
         result = a / b
@@ -704,7 +616,6 @@ class TestNumberArrayBroadcasting(unittest.TestCase):
 
     def test_comparison_broadcasting(self):
         """Test comparison with broadcasting."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([[1, 2], [3, 4]], unit=self.meter)
         b = NumberArray([2, 3], unit=self.meter)
         result = a < b
@@ -713,7 +624,6 @@ class TestNumberArrayBroadcasting(unittest.TestCase):
 
     def test_incompatible_shapes_raise(self):
         """Test that truly incompatible shapes raise error."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1, 2, 3], unit=self.meter)  # shape (3,)
         b = NumberArray([1, 2], unit=self.meter)  # shape (2,) - not compatible
         with self.assertRaises(ValueError) as ctx:
@@ -726,12 +636,9 @@ class TestNumberArrayReductions(unittest.TestCase):
     """Test reduction operations (sum, mean, etc.)."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_sum(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0, 4.0], unit=self.meter)
         total = arr.sum()
         self.assertIsInstance(total, Number)
@@ -739,36 +646,30 @@ class TestNumberArrayReductions(unittest.TestCase):
         self.assertEqual(total.unit, self.meter)
 
     def test_sum_with_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0, 4.0], unit=self.meter, uncertainty=0.1)
         total = arr.sum()
         # σ_sum = σ * sqrt(n) for uniform uncertainty
         self.assertAlmostEqual(total.uncertainty, 0.1 * math.sqrt(4))
 
     def test_mean(self):
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([2.0, 4.0, 6.0], unit=self.meter)
         avg = arr.mean()
         self.assertIsInstance(avg, Number)
         self.assertEqual(avg.quantity, 4.0)
 
     def test_mean_with_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0, 4.0], unit=self.meter, uncertainty=0.2)
         avg = arr.mean()
         # σ_mean = σ / sqrt(n) for uniform uncertainty
         self.assertAlmostEqual(avg.uncertainty, 0.2 / math.sqrt(4))
 
     def test_std(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([2.0, 4.0, 6.0, 8.0], unit=self.meter)
         s = arr.std()
         expected = np.std([2.0, 4.0, 6.0, 8.0])
         self.assertAlmostEqual(s.quantity, expected)
 
     def test_min_max(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([3.0, 1.0, 4.0, 1.0, 5.0], unit=self.meter)
         self.assertEqual(arr.min().quantity, 1.0)
         self.assertEqual(arr.max().quantity, 5.0)
@@ -779,14 +680,11 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
     """Extended arithmetic tests for coverage."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_divide_by_number(self):
         """Test NumberArray / Number."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([10.0, 20.0, 30.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.second)
         result = arr / n
@@ -794,8 +692,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_divide_by_number_with_uncertainty(self):
         """Test NumberArray / Number with uncertainty propagation."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([10.0, 20.0], unit=self.meter, uncertainty=1.0)
         n = Number(quantity=2.0, unit=self.second, uncertainty=0.1)
         result = arr / n
@@ -803,21 +699,18 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_divide_by_scalar_with_uncertainty(self):
         """Test NumberArray / scalar with uncertainty."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([10.0, 20.0], unit=self.meter, uncertainty=1.0)
         result = arr / 2
         self.assertEqual(result.uncertainty, 0.5)
 
     def test_rdiv_scalar_by_array(self):
         """Test scalar / NumberArray."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([2.0, 4.0, 5.0], unit=self.meter)
         result = 10.0 / arr
         np.testing.assert_array_equal(result.quantities, np.array([5.0, 2.5, 2.0]))
 
     def test_rdiv_scalar_by_array_with_uncertainty(self):
         """Test scalar / NumberArray with uncertainty."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([10.0, 20.0], unit=self.meter, uncertainty=1.0)
         result = 100.0 / arr
         self.assertIsNotNone(result.uncertainty)
@@ -827,8 +720,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_add_number_to_array(self):
         """Test NumberArray + Number."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=10.0, unit=self.meter)
         result = arr + n
@@ -836,8 +727,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_add_number_with_uncertainty(self):
         """Test NumberArray + Number with uncertainty."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         n = Number(quantity=10.0, unit=self.meter, uncertainty=0.2)
         result = arr + n
@@ -848,8 +737,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_radd_number(self):
         """Test Number + NumberArray (radd)."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0], unit=self.meter)
         n = Number(quantity=10.0, unit=self.meter)
         result = n + arr  # triggers __radd__
@@ -857,8 +744,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_sub_number_from_array(self):
         """Test NumberArray - Number."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([10.0, 20.0, 30.0], unit=self.meter)
         n = Number(quantity=5.0, unit=self.meter)
         result = arr - n
@@ -866,8 +751,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_rsub_number(self):
         """Test Number - NumberArray (rsub)."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0], unit=self.meter)
         n = Number(quantity=10.0, unit=self.meter)
         result = n - arr  # triggers __rsub__
@@ -875,8 +758,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_rsub_number_with_uncertainty(self):
         """Test Number - NumberArray with uncertainty."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         n = Number(quantity=10.0, unit=self.meter, uncertainty=0.2)
         result = n - arr
@@ -887,7 +768,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_pos(self):
         """Test unary positive (+arr)."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, -2.0, 3.0], unit=self.meter, uncertainty=0.1)
         result = +arr
         np.testing.assert_array_equal(result.quantities, arr.quantities)
@@ -895,7 +775,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_pos_with_per_element_uncertainty(self):
         """Test unary positive with per-element uncertainty."""
-        from ucon.integrations.numpy import NumberArray
         unc = np.array([0.1, 0.2, 0.3])
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter, uncertainty=unc)
         result = +arr
@@ -903,8 +782,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_multiply_number_by_array(self):
         """Test Number * NumberArray."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.quantity import Number
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         n = Number(quantity=2.0, unit=self.second)
         result = arr * n
@@ -912,7 +789,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_divide_arrays_incompatible_shapes(self):
         """Test division with incompatible shapes raises."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         b = NumberArray([1.0, 2.0], unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -921,7 +797,6 @@ class TestNumberArrayArithmeticExtended(unittest.TestCase):
 
     def test_divide_arrays_with_uncertainty(self):
         """Test NumberArray / NumberArray with uncertainty."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([10.0, 20.0], unit=self.meter, uncertainty=1.0)
         b = NumberArray([2.0, 4.0], unit=self.second, uncertainty=0.1)
         result = a / b
@@ -933,12 +808,10 @@ class TestNumberArrayReductionsExtended(unittest.TestCase):
     """Extended reduction tests for coverage."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_sum_with_per_element_uncertainty(self):
         """Test sum with per-element uncertainty."""
-        from ucon.integrations.numpy import NumberArray
         unc = np.array([0.1, 0.2, 0.3])
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter, uncertainty=unc)
         total = arr.sum()
@@ -948,7 +821,6 @@ class TestNumberArrayReductionsExtended(unittest.TestCase):
 
     def test_mean_with_per_element_uncertainty(self):
         """Test mean with per-element uncertainty."""
-        from ucon.integrations.numpy import NumberArray
         unc = np.array([0.1, 0.2, 0.3])
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter, uncertainty=unc)
         avg = arr.mean()
@@ -962,33 +834,27 @@ class TestNumberArrayNumpyIntegration(unittest.TestCase):
     """Test numpy integration features."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_asarray(self):
         """Test np.asarray(NumberArray)."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = np.asarray(arr)
         np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0]))
 
     def test_asarray_with_dtype(self):
         """Test np.asarray with dtype conversion."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         result = np.asarray(arr, dtype=np.float32)
         self.assertEqual(result.dtype, np.float32)
 
     def test_dimension_property(self):
         """Test dimension property."""
-        from ucon.integrations.numpy import NumberArray
-        from ucon.dimension import Dimension
         arr = NumberArray([1.0, 2.0], unit=self.meter)
         self.assertEqual(arr.dimension, Dimension.length)
 
     def test_dimension_property_dimensionless(self):
         """Test dimension property for dimensionless."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0])
         # dimensionless unit may have None dimension
         dim = arr.dimension
@@ -1000,11 +866,9 @@ class TestNumberArrayRepr(unittest.TestCase):
     """Test string representation."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_small_array_repr(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
         s = repr(arr)
         self.assertIn("m", s)
@@ -1012,13 +876,11 @@ class TestNumberArrayRepr(unittest.TestCase):
         self.assertIn("3", s)
 
     def test_large_array_truncation(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray(list(range(100)), unit=self.meter)
         s = repr(arr)
         self.assertIn("...", s)
 
     def test_repr_with_uncertainty(self):
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         s = repr(arr)
         self.assertIn("±", s)
@@ -1029,63 +891,50 @@ class TestNumberArrayNotImplemented(unittest.TestCase):
     """Test NotImplemented return for unsupported operand types."""
 
     def setUp(self):
-        from ucon import units
-        from ucon.integrations.numpy import NumberArray
         self.meter = units.meter
         self.arr = NumberArray([1.0, 2.0, 3.0], unit=self.meter)
 
     def test_mul_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__mul__("string")
         self.assertIs(result, NotImplemented)
 
     def test_truediv_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__truediv__("string")
         self.assertIs(result, NotImplemented)
 
     def test_add_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__add__("string")
         self.assertIs(result, NotImplemented)
 
     def test_sub_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__sub__("string")
         self.assertIs(result, NotImplemented)
 
     def test_rsub_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__rsub__("string")
         self.assertIs(result, NotImplemented)
 
     def test_eq_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__eq__("string")
         self.assertIs(result, NotImplemented)
 
     def test_lt_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__lt__("string")
         self.assertIs(result, NotImplemented)
 
     def test_le_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__le__("string")
         self.assertIs(result, NotImplemented)
 
     def test_gt_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__gt__("string")
         self.assertIs(result, NotImplemented)
 
     def test_ge_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__ge__("string")
         self.assertIs(result, NotImplemented)
 
     def test_ne_unsupported(self):
-        from ucon.integrations.numpy import NumberArray
         result = self.arr.__ne__("string")
         self.assertIs(result, NotImplemented)
 
@@ -1095,19 +944,16 @@ class TestNumberArrayUncertaintyEdgeCases(unittest.TestCase):
     """Test uncertainty propagation edge cases."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_mul_both_no_uncertainty(self):
         """Multiplying arrays with no uncertainty returns no uncertainty."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter)
         result = a * 2
         self.assertIsNone(result.uncertainty)
 
     def test_add_one_uncertainty_one_none(self):
         """Adding arrays where one has uncertainty propagates it."""
-        from ucon.integrations.numpy import NumberArray
         a = NumberArray([1.0, 2.0], unit=self.meter, uncertainty=0.1)
         b = NumberArray([3.0, 4.0], unit=self.meter)
         result = a + b
@@ -1116,7 +962,6 @@ class TestNumberArrayUncertaintyEdgeCases(unittest.TestCase):
 
     def test_repr_per_element_uncertainty(self):
         """Per-element uncertainty shows [...] in repr."""
-        from ucon.integrations.numpy import NumberArray
         arr = NumberArray([1.0, 2.0], unit=self.meter,
                          uncertainty=np.array([0.1, 0.2]))
         r = repr(arr)

--- a/tests/ucon/integrations/test_pandas.py
+++ b/tests/ucon/integrations/test_pandas.py
@@ -13,6 +13,10 @@ try:
     HAS_PANDAS = True
 except ImportError:
     HAS_PANDAS = False
+from ucon import units
+from ucon.core import Scale
+from ucon.integrations.pandas import NumberSeries
+from ucon.quantity import Number
 
 
 @unittest.skipUnless(HAS_PANDAS, "Pandas not installed")
@@ -20,49 +24,41 @@ class TestNumberSeriesBasic(unittest.TestCase):
     """Test NumberSeries construction and basic properties."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.foot = units.foot
         self.second = units.second
 
     def test_create_from_series(self):
-        from ucon.integrations.pandas import NumberSeries
         s = pd.Series([1.0, 2.0, 3.0])
         ns = NumberSeries(s, unit=self.meter)
         self.assertEqual(len(ns), 3)
         self.assertEqual(ns.unit, self.meter)
 
     def test_create_from_list(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries([1.0, 2.0, 3.0], unit=self.meter)
         self.assertEqual(len(ns), 3)
         self.assertIsInstance(ns.series, pd.Series)
 
     def test_default_unit_is_dimensionless(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0]))
         self.assertEqual(ns.unit, UnitProduct({}))
 
     def test_uniform_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter, uncertainty=0.1)
         self.assertEqual(ns.uncertainty, 0.1)
 
     def test_per_element_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         unc = pd.Series([0.1, 0.2, 0.3])
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter, uncertainty=unc)
         pd.testing.assert_series_equal(ns.uncertainty, unc)
 
     def test_uncertainty_length_mismatch_raises(self):
-        from ucon.integrations.pandas import NumberSeries
         with self.assertRaises(ValueError) as ctx:
             NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter,
                         uncertainty=pd.Series([0.1, 0.2]))
         self.assertIn("length", str(ctx.exception))
 
     def test_index_property(self):
-        from ucon.integrations.pandas import NumberSeries
         idx = pd.Index(['a', 'b', 'c'])
         s = pd.Series([1.0, 2.0, 3.0], index=idx)
         ns = NumberSeries(s, unit=self.meter)
@@ -74,27 +70,21 @@ class TestNumberSeriesIndexing(unittest.TestCase):
     """Test NumberSeries indexing and iteration."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_scalar_index_returns_number(self):
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         elem = ns[0]
         self.assertIsInstance(elem, Number)
         self.assertEqual(elem.quantity, 1.0)
 
     def test_slice_returns_numberseries(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter)
         sliced = ns[1:3]
         self.assertIsInstance(sliced, NumberSeries)
         self.assertEqual(len(sliced), 2)
 
     def test_label_index(self):
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         s = pd.Series([1.0, 2.0, 3.0], index=['a', 'b', 'c'])
         ns = NumberSeries(s, unit=self.meter)
         elem = ns['b']
@@ -102,8 +92,6 @@ class TestNumberSeriesIndexing(unittest.TestCase):
         self.assertEqual(elem.quantity, 2.0)
 
     def test_iteration_yields_numbers(self):
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         elements = list(ns)
         self.assertEqual(len(elements), 3)
@@ -116,12 +104,10 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
     """Test NumberSeries arithmetic operations."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_multiply_by_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns * 2
         pd.testing.assert_series_equal(
@@ -130,13 +116,11 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         self.assertEqual(result.unit, self.meter)
 
     def test_multiply_by_scalar_with_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         result = ns * 2
         self.assertEqual(result.uncertainty, 0.2)
 
     def test_rmul(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = 2 * ns
         pd.testing.assert_series_equal(
@@ -144,7 +128,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         )
 
     def test_divide_by_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([2.0, 4.0, 6.0]), unit=self.meter)
         result = ns / 2
         pd.testing.assert_series_equal(
@@ -152,7 +135,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         )
 
     def test_multiply_numberseries(self):
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter)
         b = NumberSeries(pd.Series([3.0, 4.0]), unit=self.second)
         result = a * b
@@ -161,7 +143,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         )
 
     def test_multiply_length_mismatch(self):
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter)
         with self.assertRaises(ValueError) as ctx:
@@ -169,7 +150,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         self.assertIn("Length mismatch", str(ctx.exception))
 
     def test_add_same_unit(self):
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter)
         b = NumberSeries(pd.Series([0.5, 0.5]), unit=self.meter)
         result = a + b
@@ -178,7 +158,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         )
 
     def test_add_different_unit_raises(self):
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter)
         b = NumberSeries(pd.Series([1.0, 2.0]), unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -186,7 +165,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         self.assertIn("different units", str(ctx.exception))
 
     def test_subtract(self):
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([3.0, 4.0]), unit=self.meter)
         b = NumberSeries(pd.Series([1.0, 1.0]), unit=self.meter)
         result = a - b
@@ -195,7 +173,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         )
 
     def test_negation(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, -2.0, 3.0]), unit=self.meter)
         result = -ns
         pd.testing.assert_series_equal(
@@ -203,7 +180,6 @@ class TestNumberSeriesArithmetic(unittest.TestCase):
         )
 
     def test_abs(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([-1.0, 2.0, -3.0]), unit=self.meter)
         result = abs(ns)
         pd.testing.assert_series_equal(
@@ -216,14 +192,11 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
     """Extended arithmetic tests for coverage."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_divide_by_number(self):
         """Test NumberSeries / Number."""
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([10.0, 20.0, 30.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.second)
         result = ns / n
@@ -233,8 +206,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_divide_by_number_with_uncertainty(self):
         """Test NumberSeries / Number with uncertainty."""
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([10.0, 20.0]), unit=self.meter, uncertainty=1.0)
         n = Number(quantity=2.0, unit=self.second, uncertainty=0.1)
         result = ns / n
@@ -242,7 +213,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_divide_numberseries_with_uncertainty(self):
         """Test NumberSeries / NumberSeries with uncertainty."""
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([10.0, 20.0]), unit=self.meter, uncertainty=1.0)
         b = NumberSeries(pd.Series([2.0, 4.0]), unit=self.second, uncertainty=0.1)
         result = a / b
@@ -250,8 +220,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_add_number(self):
         """Test NumberSeries + Number."""
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=10.0, unit=self.meter)
         result = ns + n
@@ -261,8 +229,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_add_number_with_uncertainty(self):
         """Test NumberSeries + Number with uncertainty."""
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         n = Number(quantity=10.0, unit=self.meter, uncertainty=0.2)
         result = ns + n
@@ -271,8 +237,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_sub_number(self):
         """Test NumberSeries - Number."""
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([10.0, 20.0, 30.0]), unit=self.meter)
         n = Number(quantity=5.0, unit=self.meter)
         result = ns - n
@@ -282,8 +246,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_multiply_by_number(self):
         """Test NumberSeries * Number."""
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.second)
         result = ns * n
@@ -293,8 +255,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_multiply_by_number_with_uncertainty(self):
         """Test NumberSeries * Number with uncertainty."""
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([10.0, 20.0]), unit=self.meter, uncertainty=1.0)
         n = Number(quantity=2.0, unit=self.second, uncertainty=0.1)
         result = ns * n
@@ -302,7 +262,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_divide_numberseries_length_mismatch(self):
         """Test division with length mismatch."""
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberSeries(pd.Series([1.0, 2.0]), unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -311,7 +270,6 @@ class TestNumberSeriesArithmeticExtended(unittest.TestCase):
 
     def test_add_length_mismatch(self):
         """Test addition with length mismatch."""
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter)
         with self.assertRaises(ValueError) as ctx:
@@ -324,14 +282,11 @@ class TestNumberSeriesConversion(unittest.TestCase):
     """Test NumberSeries unit conversion."""
 
     def setUp(self):
-        from ucon import units
-        from ucon.core import Scale
         self.meter = units.meter
         self.foot = units.foot
         self.kilometer = Scale.kilo * units.meter
 
     def test_scale_only_conversion(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.kilometer)
         result = ns.to(self.meter)
         pd.testing.assert_series_equal(
@@ -340,13 +295,11 @@ class TestNumberSeriesConversion(unittest.TestCase):
         self.assertEqual(result.unit, self.meter)
 
     def test_conversion_with_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0]), unit=self.kilometer, uncertainty=0.1)
         result = ns.to(self.meter)
         self.assertAlmostEqual(result.uncertainty, 100.0)
 
     def test_graph_based_conversion(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns.to(self.foot)
         # 1 meter ~ 3.28084 feet
@@ -361,63 +314,52 @@ class TestNumberSeriesComparison(unittest.TestCase):
     """Test comparison operators returning boolean Series."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_eq_with_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns == 2.0
         pd.testing.assert_series_equal(result, pd.Series([False, True, False]))
 
     def test_eq_with_number(self):
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         result = ns == n
         pd.testing.assert_series_equal(result, pd.Series([False, True, False]))
 
     def test_eq_with_numberseries(self):
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberSeries(pd.Series([1.0, 5.0, 3.0]), unit=self.meter)
         result = a == b
         pd.testing.assert_series_equal(result, pd.Series([True, False, True]))
 
     def test_ne_with_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns != 2.0
         pd.testing.assert_series_equal(result, pd.Series([True, False, True]))
 
     def test_lt_with_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns < 2.0
         pd.testing.assert_series_equal(result, pd.Series([True, False, False]))
 
     def test_le_with_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns <= 2.0
         pd.testing.assert_series_equal(result, pd.Series([True, True, False]))
 
     def test_gt_with_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns > 2.0
         pd.testing.assert_series_equal(result, pd.Series([False, False, True]))
 
     def test_ge_with_scalar(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = ns >= 2.0
         pd.testing.assert_series_equal(result, pd.Series([False, True, True]))
 
     def test_comparison_different_unit_raises(self):
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter)
         b = NumberSeries(pd.Series([1.0, 2.0]), unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -425,7 +367,6 @@ class TestNumberSeriesComparison(unittest.TestCase):
         self.assertIn("different units", str(ctx.exception))
 
     def test_comparison_for_filtering(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0, 4.0, 5.0]), unit=self.meter)
         mask = ns > 2.5
         filtered = ns.series[mask]
@@ -440,12 +381,9 @@ class TestNumberSeriesReductions(unittest.TestCase):
     """Test reduction operations (sum, mean, etc.)."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_sum(self):
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter)
         total = ns.sum()
         self.assertIsInstance(total, Number)
@@ -453,34 +391,28 @@ class TestNumberSeriesReductions(unittest.TestCase):
         self.assertEqual(total.unit, self.meter)
 
     def test_sum_with_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter, uncertainty=0.1)
         total = ns.sum()
         self.assertAlmostEqual(total.uncertainty, 0.1 * math.sqrt(4))
 
     def test_mean(self):
-        from ucon.integrations.pandas import NumberSeries
-        from ucon.quantity import Number
         ns = NumberSeries(pd.Series([2.0, 4.0, 6.0]), unit=self.meter)
         avg = ns.mean()
         self.assertIsInstance(avg, Number)
         self.assertEqual(avg.quantity, 4.0)
 
     def test_mean_with_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter, uncertainty=0.2)
         avg = ns.mean()
         self.assertAlmostEqual(avg.uncertainty, 0.2 / math.sqrt(4))
 
     def test_std(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([2.0, 4.0, 6.0, 8.0]), unit=self.meter)
         s = ns.std()
         expected = pd.Series([2.0, 4.0, 6.0, 8.0]).std()
         self.assertAlmostEqual(s.quantity, expected)
 
     def test_min_max(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([3.0, 1.0, 4.0, 1.0, 5.0]), unit=self.meter)
         self.assertEqual(ns.min().quantity, 1.0)
         self.assertEqual(ns.max().quantity, 5.0)
@@ -491,24 +423,20 @@ class TestNumberSeriesRepr(unittest.TestCase):
     """Test string representation."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_small_series_repr(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         s = repr(ns)
         self.assertIn("NumberSeries", s)
         self.assertIn("m", s)
 
     def test_large_series_truncation(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series(range(100)), unit=self.meter)
         s = repr(ns)
         self.assertIn("...", s)
 
     def test_repr_with_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         s = repr(ns)
         self.assertIn("\u00b1", s)
@@ -519,32 +447,27 @@ class TestUconSeriesAccessor(unittest.TestCase):
     """Test the pandas Series accessor."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.foot = units.foot
 
     def test_accessor_with_unit(self):
-        from ucon.integrations.pandas import NumberSeries
         s = pd.Series([1.7, 1.8, 1.9])
         ns = s.ucon.with_unit(self.meter)
         self.assertIsInstance(ns, NumberSeries)
         self.assertEqual(ns.unit, self.meter)
 
     def test_accessor_callable(self):
-        from ucon.integrations.pandas import NumberSeries
         s = pd.Series([1.7, 1.8, 1.9])
         ns = s.ucon(self.meter)
         self.assertIsInstance(ns, NumberSeries)
         self.assertEqual(ns.unit, self.meter)
 
     def test_accessor_with_uncertainty(self):
-        from ucon.integrations.pandas import NumberSeries
         s = pd.Series([1.7, 1.8, 1.9])
         ns = s.ucon.with_unit(self.meter, uncertainty=0.01)
         self.assertEqual(ns.uncertainty, 0.01)
 
     def test_accessor_conversion_chain(self):
-        from ucon.integrations.pandas import NumberSeries
         s = pd.Series([1.0, 2.0, 3.0])
         result = s.ucon(self.meter).to(self.foot)
         self.assertIsInstance(result, NumberSeries)
@@ -558,11 +481,9 @@ class TestNumberSeriesToFrame(unittest.TestCase):
     """Test DataFrame conversion."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_to_frame_default_name(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         df = ns.to_frame()
         self.assertIsInstance(df, pd.DataFrame)
@@ -570,7 +491,6 @@ class TestNumberSeriesToFrame(unittest.TestCase):
         self.assertIn('m', df.columns[0])
 
     def test_to_frame_custom_name(self):
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
         df = ns.to_frame(name='height')
         self.assertEqual(df.columns[0], 'height')
@@ -581,8 +501,6 @@ class TestNumberSeriesNotImplemented(unittest.TestCase):
     """Test NotImplemented return for unsupported operand types."""
 
     def setUp(self):
-        from ucon import units
-        from ucon.integrations.pandas import NumberSeries
         self.meter = units.meter
         self.ns = NumberSeries(pd.Series([1.0, 2.0, 3.0]), unit=self.meter)
 
@@ -632,19 +550,16 @@ class TestNumberSeriesUncertaintyEdgeCases(unittest.TestCase):
     """Test uncertainty propagation edge cases."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_mul_both_no_uncertainty(self):
         """Multiplying series with no uncertainty returns no uncertainty."""
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter)
         result = a * 2
         self.assertIsNone(result.uncertainty)
 
     def test_add_one_uncertainty_one_none(self):
         """Adding series where one has uncertainty propagates it."""
-        from ucon.integrations.pandas import NumberSeries
         a = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         b = NumberSeries(pd.Series([3.0, 4.0]), unit=self.meter)
         result = a + b
@@ -652,7 +567,6 @@ class TestNumberSeriesUncertaintyEdgeCases(unittest.TestCase):
 
     def test_repr_per_element_uncertainty(self):
         """Per-element uncertainty shows [...] in repr."""
-        from ucon.integrations.pandas import NumberSeries
         ns = NumberSeries(pd.Series([1.0, 2.0]), unit=self.meter,
                           uncertainty=pd.Series([0.1, 0.2]))
         r = repr(ns)

--- a/tests/ucon/integrations/test_polars.py
+++ b/tests/ucon/integrations/test_polars.py
@@ -12,6 +12,12 @@ try:
     HAS_POLARS = True
 except ImportError:
     HAS_POLARS = False
+from ucon import Number
+from ucon import units
+from ucon.core import Dimension
+from ucon.core import Scale
+from ucon.integrations.polars import NumberColumn
+from ucon.quantity import Number
 
 
 @unittest.skipUnless(HAS_POLARS, "Polars not installed")
@@ -19,42 +25,35 @@ class TestNumberColumnBasic(unittest.TestCase):
     """Test NumberColumn construction and basic properties."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.foot = units.foot
         self.second = units.second
 
     def test_create_from_series(self):
-        from ucon.integrations.polars import NumberColumn
         s = pl.Series([1.0, 2.0, 3.0])
         nc = NumberColumn(s, unit=self.meter)
         self.assertEqual(len(nc), 3)
         self.assertEqual(nc.unit, self.meter)
 
     def test_create_from_list(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn([1.0, 2.0, 3.0], unit=self.meter)
         self.assertEqual(len(nc), 3)
         self.assertIsInstance(nc.series, pl.Series)
 
     def test_default_unit_is_dimensionless(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0]))
         self.assertEqual(nc.unit, UnitProduct({}))
 
     def test_uniform_uncertainty(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter, uncertainty=0.1)
         self.assertEqual(nc.uncertainty, 0.1)
 
     def test_per_element_uncertainty(self):
-        from ucon.integrations.polars import NumberColumn
         unc = pl.Series([0.1, 0.2, 0.3])
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter, uncertainty=unc)
         self.assertEqual(len(nc.uncertainty), 3)
 
     def test_uncertainty_length_mismatch_raises(self):
-        from ucon.integrations.polars import NumberColumn
         with self.assertRaises(ValueError) as ctx:
             NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter,
                         uncertainty=pl.Series([0.1, 0.2]))
@@ -66,27 +65,21 @@ class TestNumberColumnIndexing(unittest.TestCase):
     """Test NumberColumn indexing and iteration."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_scalar_index_returns_number(self):
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         elem = nc[0]
         self.assertIsInstance(elem, Number)
         self.assertEqual(elem.quantity, 1.0)
 
     def test_slice_returns_numbercolumn(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter)
         sliced = nc[1:3]
         self.assertIsInstance(sliced, NumberColumn)
         self.assertEqual(len(sliced), 2)
 
     def test_iteration_yields_numbers(self):
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         elements = list(nc)
         self.assertEqual(len(elements), 3)
@@ -99,44 +92,37 @@ class TestNumberColumnArithmetic(unittest.TestCase):
     """Test NumberColumn arithmetic operations."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_multiply_by_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc * 2
         self.assertEqual(result.series.to_list(), [2.0, 4.0, 6.0])
         self.assertEqual(result.unit, self.meter)
 
     def test_multiply_by_scalar_with_uncertainty(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         result = nc * 2
         self.assertEqual(result.uncertainty, 0.2)
 
     def test_rmul(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = 2 * nc
         self.assertEqual(result.series.to_list(), [2.0, 4.0, 6.0])
 
     def test_divide_by_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([2.0, 4.0, 6.0]), unit=self.meter)
         result = nc / 2
         self.assertEqual(result.series.to_list(), [1.0, 2.0, 3.0])
 
     def test_multiply_numbercolumns(self):
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         b = NumberColumn(pl.Series([3.0, 4.0]), unit=self.second)
         result = a * b
         self.assertEqual(result.series.to_list(), [3.0, 8.0])
 
     def test_multiply_length_mismatch(self):
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         with self.assertRaises(ValueError) as ctx:
@@ -144,14 +130,12 @@ class TestNumberColumnArithmetic(unittest.TestCase):
         self.assertIn("Length mismatch", str(ctx.exception))
 
     def test_add_same_unit(self):
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         b = NumberColumn(pl.Series([0.5, 0.5]), unit=self.meter)
         result = a + b
         self.assertEqual(result.series.to_list(), [1.5, 2.5])
 
     def test_add_different_unit_raises(self):
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 2.0]), unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -159,20 +143,17 @@ class TestNumberColumnArithmetic(unittest.TestCase):
         self.assertIn("different units", str(ctx.exception))
 
     def test_subtract(self):
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([3.0, 4.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 1.0]), unit=self.meter)
         result = a - b
         self.assertEqual(result.series.to_list(), [2.0, 3.0])
 
     def test_negation(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, -2.0, 3.0]), unit=self.meter)
         result = -nc
         self.assertEqual(result.series.to_list(), [-1.0, 2.0, -3.0])
 
     def test_abs(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([-1.0, 2.0, -3.0]), unit=self.meter)
         result = abs(nc)
         self.assertEqual(result.series.to_list(), [1.0, 2.0, 3.0])
@@ -183,63 +164,52 @@ class TestNumberColumnComparison(unittest.TestCase):
     """Test comparison operators returning boolean Series."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_eq_with_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc == 2.0
         self.assertEqual(result.to_list(), [False, True, False])
 
     def test_eq_with_number(self):
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         result = nc == n
         self.assertEqual(result.to_list(), [False, True, False])
 
     def test_eq_with_numbercolumn(self):
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 5.0, 3.0]), unit=self.meter)
         result = a == b
         self.assertEqual(result.to_list(), [True, False, True])
 
     def test_ne_with_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc != 2.0
         self.assertEqual(result.to_list(), [True, False, True])
 
     def test_lt_with_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc < 2.0
         self.assertEqual(result.to_list(), [True, False, False])
 
     def test_le_with_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc <= 2.0
         self.assertEqual(result.to_list(), [True, True, False])
 
     def test_gt_with_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc > 2.0
         self.assertEqual(result.to_list(), [False, False, True])
 
     def test_ge_with_scalar(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc >= 2.0
         self.assertEqual(result.to_list(), [False, True, True])
 
     def test_comparison_different_unit_raises(self):
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 2.0]), unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -247,7 +217,6 @@ class TestNumberColumnComparison(unittest.TestCase):
         self.assertIn("different units", str(ctx.exception))
 
     def test_comparison_for_filtering(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0, 4.0, 5.0]), unit=self.meter)
         mask = nc > 2.5
         filtered = nc.series.filter(mask)
@@ -259,27 +228,22 @@ class TestNumberColumnConversion(unittest.TestCase):
     """Test NumberColumn unit conversion."""
 
     def setUp(self):
-        from ucon import units
-        from ucon.core import Scale
         self.meter = units.meter
         self.foot = units.foot
         self.kilometer = Scale.kilo * units.meter
 
     def test_scale_only_conversion(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.kilometer)
         result = nc.to(self.meter)
         self.assertEqual(result.series.to_list(), [1000.0, 2000.0, 3000.0])
         self.assertEqual(result.unit, self.meter)
 
     def test_conversion_with_uncertainty(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0]), unit=self.kilometer, uncertainty=0.1)
         result = nc.to(self.meter)
         self.assertAlmostEqual(result.uncertainty, 100.0)
 
     def test_graph_based_conversion(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc.to(self.foot)
         # 1 meter ~ 3.28084 feet
@@ -293,12 +257,9 @@ class TestNumberColumnReductions(unittest.TestCase):
     """Test reduction operations (sum, mean, etc.)."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_sum(self):
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter)
         total = nc.sum()
         self.assertIsInstance(total, Number)
@@ -306,34 +267,28 @@ class TestNumberColumnReductions(unittest.TestCase):
         self.assertEqual(total.unit, self.meter)
 
     def test_sum_with_uncertainty(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter, uncertainty=0.1)
         total = nc.sum()
         self.assertAlmostEqual(total.uncertainty, 0.1 * math.sqrt(4))
 
     def test_mean(self):
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([2.0, 4.0, 6.0]), unit=self.meter)
         avg = nc.mean()
         self.assertIsInstance(avg, Number)
         self.assertEqual(avg.quantity, 4.0)
 
     def test_mean_with_uncertainty(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0, 4.0]), unit=self.meter, uncertainty=0.2)
         avg = nc.mean()
         self.assertAlmostEqual(avg.uncertainty, 0.2 / math.sqrt(4))
 
     def test_std(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([2.0, 4.0, 6.0, 8.0]), unit=self.meter)
         s = nc.std()
         expected = pl.Series([2.0, 4.0, 6.0, 8.0]).std()
         self.assertAlmostEqual(s.quantity, expected)
 
     def test_min_max(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([3.0, 1.0, 4.0, 1.0, 5.0]), unit=self.meter)
         self.assertEqual(nc.min().quantity, 1.0)
         self.assertEqual(nc.max().quantity, 5.0)
@@ -344,24 +299,20 @@ class TestNumberColumnRepr(unittest.TestCase):
     """Test string representation."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_small_column_repr(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         s = repr(nc)
         self.assertIn("NumberColumn", s)
         self.assertIn("m", s)
 
     def test_large_column_truncation(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series(list(range(100))), unit=self.meter)
         s = repr(nc)
         self.assertIn("...", s)
 
     def test_repr_with_uncertainty(self):
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         s = repr(nc)
         self.assertIn("\u00b1", s)
@@ -372,12 +323,9 @@ class TestNumberColumnToList(unittest.TestCase):
     """Test to_list conversion."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_to_list(self):
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         numbers = nc.to_list()
         self.assertEqual(len(numbers), 3)
@@ -391,14 +339,11 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
     """Extended arithmetic tests for better coverage."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_divide_by_number(self):
         """Test division by a Number."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([10.0, 20.0, 30.0]), unit=self.meter)
         divisor = Number(quantity=2.0, unit=self.second)
         result = nc / divisor
@@ -406,8 +351,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_divide_by_number_with_uncertainty(self):
         """Test division by Number with uncertainty propagation."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([10.0, 20.0]), unit=self.meter, uncertainty=1.0)
         divisor = Number(quantity=2.0, unit=self.second, uncertainty=0.1)
         result = nc / divisor
@@ -415,7 +358,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_divide_numbercolumn_by_numbercolumn(self):
         """Test division between two NumberColumns."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([10.0, 20.0, 30.0]), unit=self.meter)
         b = NumberColumn(pl.Series([2.0, 4.0, 5.0]), unit=self.second)
         result = a / b
@@ -423,7 +365,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_divide_numbercolumn_with_uncertainty(self):
         """Test division between NumberColumns with uncertainty."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([10.0, 20.0]), unit=self.meter, uncertainty=1.0)
         b = NumberColumn(pl.Series([2.0, 4.0]), unit=self.second, uncertainty=0.1)
         result = a / b
@@ -431,7 +372,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_divide_length_mismatch(self):
         """Test division with mismatched lengths raises."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 2.0]), unit=self.second)
         with self.assertRaises(ValueError) as ctx:
@@ -440,8 +380,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_add_number(self):
         """Test adding a Number to NumberColumn."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=0.5, unit=self.meter)
         result = nc + n
@@ -449,8 +387,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_add_number_with_uncertainty(self):
         """Test adding Number with uncertainty propagation."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         n = Number(quantity=0.5, unit=self.meter, uncertainty=0.05)
         result = nc + n
@@ -458,7 +394,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_add_length_mismatch(self):
         """Test addition with mismatched lengths raises."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         with self.assertRaises(ValueError) as ctx:
@@ -467,8 +402,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_sub_number(self):
         """Test subtracting a Number from NumberColumn."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([3.0, 4.0, 5.0]), unit=self.meter)
         n = Number(quantity=1.0, unit=self.meter)
         result = nc - n
@@ -476,8 +409,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_sub_number_with_uncertainty(self):
         """Test subtracting Number with uncertainty propagation."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([3.0, 4.0]), unit=self.meter, uncertainty=0.1)
         n = Number(quantity=1.0, unit=self.meter, uncertainty=0.05)
         result = nc - n
@@ -485,7 +416,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_sub_length_mismatch(self):
         """Test subtraction with mismatched lengths raises."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         with self.assertRaises(ValueError) as ctx:
@@ -494,8 +424,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_multiply_by_number(self):
         """Test multiplying NumberColumn by Number."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.second)
         result = nc * n
@@ -503,8 +431,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_multiply_by_number_with_uncertainty(self):
         """Test multiplying by Number with uncertainty propagation."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([10.0, 20.0]), unit=self.meter, uncertainty=1.0)
         n = Number(quantity=2.0, unit=self.second, uncertainty=0.1)
         result = nc * n
@@ -512,7 +438,6 @@ class TestNumberColumnArithmeticExtended(unittest.TestCase):
 
     def test_multiply_numbercolumns_with_uncertainty(self):
         """Test multiplying NumberColumns with uncertainty."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([10.0, 20.0]), unit=self.meter, uncertainty=1.0)
         b = NumberColumn(pl.Series([2.0, 3.0]), unit=self.second, uncertainty=0.1)
         result = a * b
@@ -524,14 +449,11 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
     """Extended comparison tests for better coverage."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
         self.second = units.second
 
     def test_lt_with_number(self):
         """Test less-than comparison with Number."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.5, unit=self.meter)
         result = nc < n
@@ -539,7 +461,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_lt_with_numbercolumn(self):
         """Test less-than comparison with NumberColumn."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 3.0, 2.0]), unit=self.meter)
         b = NumberColumn(pl.Series([2.0, 2.0, 2.0]), unit=self.meter)
         result = a < b
@@ -547,8 +468,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_le_with_number(self):
         """Test less-equal comparison with Number."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         result = nc <= n
@@ -556,7 +475,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_le_with_numbercolumn(self):
         """Test less-equal comparison with NumberColumn."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([2.0, 2.0, 2.0]), unit=self.meter)
         result = a <= b
@@ -564,8 +482,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_gt_with_number(self):
         """Test greater-than comparison with Number."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=1.5, unit=self.meter)
         result = nc > n
@@ -573,7 +489,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_gt_with_numbercolumn(self):
         """Test greater-than comparison with NumberColumn."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 3.0, 2.0]), unit=self.meter)
         b = NumberColumn(pl.Series([2.0, 2.0, 2.0]), unit=self.meter)
         result = a > b
@@ -581,8 +496,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_ge_with_number(self):
         """Test greater-equal comparison with Number."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         result = nc >= n
@@ -590,7 +503,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_ge_with_numbercolumn(self):
         """Test greater-equal comparison with NumberColumn."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([2.0, 2.0, 2.0]), unit=self.meter)
         result = a >= b
@@ -598,8 +510,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_ne_with_number(self):
         """Test not-equal comparison with Number."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.quantity import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         n = Number(quantity=2.0, unit=self.meter)
         result = nc != n
@@ -607,7 +517,6 @@ class TestNumberColumnComparisonExtended(unittest.TestCase):
 
     def test_ne_with_numbercolumn(self):
         """Test not-equal comparison with NumberColumn."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         b = NumberColumn(pl.Series([1.0, 5.0, 3.0]), unit=self.meter)
         result = a != b
@@ -619,12 +528,10 @@ class TestNumberColumnReductionsExtended(unittest.TestCase):
     """Extended reduction tests for better coverage."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_sum_with_per_element_uncertainty(self):
         """Test sum with per-element uncertainty."""
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(
             pl.Series([1.0, 2.0, 3.0, 4.0]),
             unit=self.meter,
@@ -638,7 +545,6 @@ class TestNumberColumnReductionsExtended(unittest.TestCase):
 
     def test_mean_with_per_element_uncertainty(self):
         """Test mean with per-element uncertainty."""
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(
             pl.Series([1.0, 2.0, 3.0, 4.0]),
             unit=self.meter,
@@ -654,32 +560,25 @@ class TestNumberColumnProperties(unittest.TestCase):
     """Test NumberColumn properties for coverage."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_shape_property(self):
         """Test shape property."""
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         self.assertEqual(nc.shape, (3,))
 
     def test_dtype_property(self):
         """Test dtype property."""
-        from ucon.integrations.polars import NumberColumn
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         self.assertEqual(nc.dtype, pl.Float64)
 
     def test_dimension_property(self):
         """Test dimension property."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon.core import Dimension
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         self.assertEqual(nc.dimension, Dimension.length)
 
     def test_dimension_property_unitproduct(self):
         """Test dimension property with UnitProduct."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon import units
         area_unit = units.meter * units.meter
         nc = NumberColumn(pl.Series([1.0, 2.0]), unit=area_unit)
         dim = nc.dimension
@@ -691,8 +590,6 @@ class TestNumberColumnNotImplemented(unittest.TestCase):
     """Test NotImplemented return for unsupported operand types."""
 
     def setUp(self):
-        from ucon import units
-        from ucon.integrations.polars import NumberColumn
         self.meter = units.meter
         self.nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
 
@@ -742,19 +639,16 @@ class TestNumberColumnUncertaintyEdgeCases(unittest.TestCase):
     """Test uncertainty propagation edge cases."""
 
     def setUp(self):
-        from ucon import units
         self.meter = units.meter
 
     def test_mul_both_no_uncertainty(self):
         """Multiplying columns with no uncertainty returns no uncertainty."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter)
         result = a * 2
         self.assertIsNone(result.uncertainty)
 
     def test_add_one_uncertainty_one_none(self):
         """Adding columns where one has uncertainty propagates it."""
-        from ucon.integrations.polars import NumberColumn
         a = NumberColumn(pl.Series([1.0, 2.0]), unit=self.meter, uncertainty=0.1)
         b = NumberColumn(pl.Series([3.0, 4.0]), unit=self.meter)
         result = a + b
@@ -762,8 +656,6 @@ class TestNumberColumnUncertaintyEdgeCases(unittest.TestCase):
 
     def test_to_list(self):
         """to_list() returns list of Number instances."""
-        from ucon.integrations.polars import NumberColumn
-        from ucon import Number
         nc = NumberColumn(pl.Series([1.0, 2.0, 3.0]), unit=self.meter)
         result = nc.to_list()
         self.assertEqual(len(result), 3)

--- a/tests/ucon/integrations/test_pydantic.py
+++ b/tests/ucon/integrations/test_pydantic.py
@@ -16,6 +16,12 @@ import unittest
 
 from ucon import units
 from ucon.quantity import Number as CoreNumber
+from ucon.core import Dimension
+from ucon.dimension import ENERGY
+from ucon.integrations.pydantic import Number
+from ucon.integrations.pydantic import Number, constrained_number
+from ucon.kinds import Kind, KindLattice
+from ucon.system import active_system, use
 
 
 class TestPydanticIntegration(unittest.TestCase):
@@ -25,7 +31,6 @@ class TestPydanticIntegration(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -79,7 +84,6 @@ class TestPydanticSerialization(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -139,7 +143,6 @@ class TestPydanticRoundtrip(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -193,7 +196,6 @@ class TestPydanticScaledUnits(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -239,7 +241,6 @@ class TestPydanticCompositeUnits(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -309,7 +310,6 @@ class TestPydanticValidationErrors(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -353,8 +353,6 @@ class TestPydanticDimensionConstraints(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
-            from ucon.core import Dimension
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -424,8 +422,6 @@ class TestPydanticConstrainedNumber(unittest.TestCase):
         try:
             from pydantic import BaseModel, ValidationError
             from pydantic.functional_validators import AfterValidator
-            from ucon.integrations.pydantic import Number, constrained_number
-            from ucon.core import Dimension
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number
@@ -474,8 +470,6 @@ class TestPydanticJsonSchema(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel
-            from ucon.integrations.pydantic import Number
-            from ucon.core import Dimension
             cls.BaseModel = BaseModel
             cls.Number = Number
             cls.Dimension = Dimension
@@ -504,11 +498,6 @@ class TestPydanticKindIntegration(unittest.TestCase):
     def setUpClass(cls):
         try:
             from pydantic import BaseModel, ValidationError
-            from ucon.integrations.pydantic import Number
-            from ucon.core import Dimension
-            from ucon.dimension import ENERGY
-            from ucon.kinds import Kind, KindLattice
-            from ucon.system import active_system, use
             cls.BaseModel = BaseModel
             cls.ValidationError = ValidationError
             cls.Number = Number

--- a/tests/ucon/parsing/test_parse.py
+++ b/tests/ucon/parsing/test_parse.py
@@ -8,6 +8,7 @@ import pytest
 from ucon import parse, Number, using_conversion_graph, CGS
 from ucon.units import UnknownUnitError, meter, second, kilogram, hour, mile
 from ucon.parsing import _Tokenizer, _TokenType, ParseError
+from ucon.resolver import parse_unit
 
 
 class TestParseBasicQuantities:
@@ -250,13 +251,11 @@ class TestParserErrors:
 
     def test_number_in_unit_position_raises(self):
         """A bare number (other than 1) in unit position raises ParseError."""
-        from ucon.resolver import parse_unit
         with pytest.raises(ParseError, match="Expected unit"):
             parse_unit("5*m")
 
     def test_operator_in_unit_position_raises(self):
         """An operator at the start of an expression raises ParseError."""
-        from ucon.resolver import parse_unit
         with pytest.raises(ParseError, match="Expected unit"):
             parse_unit("*m")
 

--- a/tests/ucon/parsing/test_unit_parsing.py
+++ b/tests/ucon/parsing/test_unit_parsing.py
@@ -18,6 +18,8 @@ from ucon import units, Scale, Dimension, Number
 from ucon.core import Unit, UnitProduct, UnitFactor
 from ucon.resolver import parse_unit
 from ucon.units import UnknownUnitError
+from ucon.parsing import ParseError
+from ucon.resolver import register_unit
 
 
 class TestSimpleUnitLookup(unittest.TestCase):
@@ -525,13 +527,11 @@ class TestRecursiveDescentParser(unittest.TestCase):
 
     def test_unbalanced_parentheses_error(self):
         """GIVEN W/(m²*K (missing close paren) THEN raises ValueError with position."""
-        from ucon.parsing import ParseError
         with self.assertRaises((ValueError, ParseError)):
             parse_unit("W/(m²*K")
 
     def test_extra_close_paren_error(self):
         """Extra closing parenthesis should raise error."""
-        from ucon.parsing import ParseError
         with self.assertRaises((ValueError, ParseError)):
             parse_unit("W/(m²*K))")
 
@@ -598,7 +598,6 @@ class TestResolverEdgeCases(unittest.TestCase):
 
     def test_register_unit_empty_name_noop(self):
         """register_unit with empty name does nothing."""
-        from ucon.resolver import register_unit
         u = Unit(name='', dimension=Dimension.length)
         # Should not raise, should be no-op
         register_unit(u)

--- a/tests/ucon/system/test_active_context.py
+++ b/tests/ucon/system/test_active_context.py
@@ -36,6 +36,8 @@ from ucon import (
     use,
 )
 from ucon._active import _active as _active_var
+from ucon.core import Unit as _Unit
+from ucon.core._parsing_graph import _parsing_graph
 
 
 class TestActiveContextType(unittest.TestCase):
@@ -207,14 +209,12 @@ class TestUseSetsParsigGraph(unittest.TestCase):
     """``use()`` sets ``_parsing_graph`` so name resolution works."""
 
     def test_parsing_graph_set_inside_use(self):
-        from ucon.core._parsing_graph import _parsing_graph
         sys = active_system()
         with use(sys):
             pg = _parsing_graph.get()
             self.assertIs(pg, sys.conversion_graph)
 
     def test_parsing_graph_restored_after_use(self):
-        from ucon.core._parsing_graph import _parsing_graph
         before = _parsing_graph.get()
         sys = active_system()
         with use(sys):
@@ -222,7 +222,6 @@ class TestUseSetsParsigGraph(unittest.TestCase):
         self.assertIs(_parsing_graph.get(), before)
 
     def test_nested_use_parsing_graph_restores_correctly(self):
-        from ucon.core._parsing_graph import _parsing_graph
         sys = active_system()
         with use(sys) as outer_ctx:
             outer_pg = _parsing_graph.get()
@@ -235,7 +234,6 @@ class TestUseSetsParsigGraph(unittest.TestCase):
 
     def test_use_enables_unit_name_resolution(self):
         """Custom units on the system's graph are resolvable within use()."""
-        from ucon.core import Unit as _Unit
         sys = active_system()
         dim = sys.dimensions["length"]
         novel = _Unit(name="ucon_test_parsing_unit", dimension=dim, aliases=())

--- a/tests/ucon/system/test_adopt.py
+++ b/tests/ucon/system/test_adopt.py
@@ -19,6 +19,9 @@ import unittest
 import ucon
 from ucon import Number, Unit, UnitFactor, UnitProduct, UnknownUnitError
 from ucon.system import UnitSystem
+from ucon.dimension import ENERGY
+from ucon.dimension import VELOCITY
+from ucon.kinds import Kind
 
 
 def _active() -> UnitSystem:
@@ -119,8 +122,6 @@ class TestAdoptKindPreservation(unittest.TestCase):
     """``adopt`` preserves ``Number.kind`` through cross-system movement."""
 
     def test_adopt_preserves_kind_plain_unit(self):
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
         s = _active()
         ke = Kind("kinetic_energy", dimension=ENERGY)
         joule = s.units["joule"]
@@ -130,8 +131,6 @@ class TestAdoptKindPreservation(unittest.TestCase):
         self.assertEqual(out.quantity, 100.0)
 
     def test_adopt_preserves_kind_unit_product(self):
-        from ucon.dimension import VELOCITY
-        from ucon.kinds import Kind
         s = _active()
         speed_kind = Kind("speed", dimension=VELOCITY)
         meter = s.units["meter"]

--- a/tests/ucon/system/test_algebra.py
+++ b/tests/ucon/system/test_algebra.py
@@ -25,6 +25,8 @@ from ucon.system import (
     ExtendConflict,
     UnitSystem,
 )
+from ucon.basis import BasisGraph
+from ucon.core import Unit as _Unit
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +112,6 @@ class TestExtend(unittest.TestCase):
         s = _active()
         # Build a conflict by overriding the existing 'meter' definition.
         meter = s.units["meter"]
-        from ucon.core import Unit as _Unit
         clashing = _Unit(
             name=meter.name,
             dimension=meter.dimension,
@@ -125,7 +126,6 @@ class TestExtend(unittest.TestCase):
     def test_extend_prefer_self_keeps_lhs(self):
         s = _active()
         meter = s.units["meter"]
-        from ucon.core import Unit as _Unit
         clashing = _Unit(
             name=meter.name,
             dimension=meter.dimension,
@@ -138,7 +138,6 @@ class TestExtend(unittest.TestCase):
     def test_extend_prefer_other_takes_rhs(self):
         s = _active()
         meter = s.units["meter"]
-        from ucon.core import Unit as _Unit
         clashing = _Unit(
             name=meter.name,
             dimension=meter.dimension,
@@ -223,7 +222,6 @@ class TestExtendMany(unittest.TestCase):
         )
 
     def test_extend_many_raise_on_conflict(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         meter = s.units["meter"]
         clashing = _Unit(
@@ -322,7 +320,6 @@ class TestMerge(unittest.TestCase):
     def test_merge_resolver_called_only_on_conflict(self):
         s = _active()
         meter = s.units["meter"]
-        from ucon.core import Unit as _Unit
         rhs_meter = _Unit(
             name=meter.name,
             dimension=meter.dimension,
@@ -362,7 +359,6 @@ class TestMerge(unittest.TestCase):
         self.assertEqual(set(result.dimensions.keys()), set(s.dimensions.keys()))
 
     def test_merge_adopts_rhs_only_unit_without_invoking_resolver(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         length = s.dimensions["length"]
         novel = _Unit(name="ucon_merge_rhs_only", dimension=length, aliases=())
@@ -390,7 +386,6 @@ class TestMerge(unittest.TestCase):
 class TestWithUnit(unittest.TestCase):
 
     def test_with_unit_adds_to_registry(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         length = s.dimensions["length"]
         # Use a name guaranteed not to clash with existing units.
@@ -406,7 +401,6 @@ class TestWithUnit(unittest.TestCase):
         self.assertIs(out, s)
 
     def test_with_unit_conflict_raises(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         meter = s.units["meter"]
         clashing = _Unit(
@@ -421,7 +415,6 @@ class TestWithUnit(unittest.TestCase):
 class TestWithConversion(unittest.TestCase):
 
     def test_with_conversion_registers_edge(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         length = s.dimensions["length"]
         a = _Unit(name="ucon_test_a", dimension=length, aliases=())
@@ -515,7 +508,6 @@ class TestExtendConversionEdgeConflict(unittest.TestCase):
     """
 
     def _conflicting_pair(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         length = s.dimensions["length"]
         a = _Unit(name="ucon_edge_a", dimension=length, aliases=())
@@ -568,7 +560,6 @@ class TestWithBasisGraph(unittest.TestCase):
         self.assertIs(s.with_basis_graph(s.basis_graph), s)
 
     def test_with_basis_graph_different_returns_new_system(self):
-        from ucon.basis import BasisGraph
         s = _active()
         other_graph = BasisGraph()
         out = s.with_basis_graph(other_graph)

--- a/tests/ucon/system/test_bridge.py
+++ b/tests/ucon/system/test_bridge.py
@@ -27,6 +27,10 @@ from ucon import (
     UnknownUnitError,
 )
 from ucon.system import UnitSystem
+from ucon import UnitProduct
+from ucon.dimension import ENERGY
+from ucon.dimension import LENGTH
+from ucon.kinds import Kind
 
 
 def _active() -> UnitSystem:
@@ -70,7 +74,6 @@ class TestBridgeIdentity(unittest.TestCase):
         self.assertIs(out.unit, s.units["meter"])
 
     def test_identity_bridge_applies_to_unit_product(self):
-        from ucon import UnitProduct
         s = _active()
         b = Bridge(src=s, dst=s)
         product = UnitProduct({s.units["meter"]: 1.0, s.units["second"]: -1.0})
@@ -266,8 +269,6 @@ class TestBridgeKindPreservation(unittest.TestCase):
     """``Bridge.apply`` preserves ``Number.kind``."""
 
     def test_bridge_apply_preserves_kind(self):
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
         s = _active()
         ke = Kind("kinetic_energy", dimension=ENERGY)
         n = Number(100.0, s.units["joule"], kind=ke)
@@ -284,8 +285,6 @@ class TestBridgeKindPreservation(unittest.TestCase):
         self.assertIsNone(out.kind)
 
     def test_bridge_apply_preserves_kind_with_rename(self):
-        from ucon.dimension import LENGTH
-        from ucon.kinds import Kind
         src = _active()
         dst = _system_with_metre_synonym()
         distance_kind = Kind("distance", dimension=LENGTH)

--- a/tests/ucon/system/test_relations.py
+++ b/tests/ucon/system/test_relations.py
@@ -27,6 +27,7 @@ import ucon
 from ucon import ContextEdge
 from ucon.maps import LinearMap
 from ucon.system import BaseUnits, RegistryDiff, SystemDiff, UnitSystem
+from ucon.core import Unit as _Unit
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +118,6 @@ class TestSubsystemOf(unittest.TestCase):
         self.assertFalse(s.subsystem_of(length))
 
     def test_redefined_unit_breaks_subsystem(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         meter = s.units["meter"]
         rebadged = _Unit(
@@ -151,7 +151,6 @@ class TestSubsystemOf(unittest.TestCase):
         self.assertFalse(s.subsystem_of(other))
 
     def test_missing_conversion_edge_breaks_subsystem(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         length = s.dimensions["length"]
         a = _Unit(name="ucon_rel_a", dimension=length, aliases=())
@@ -190,7 +189,6 @@ class TestCompatibleWith(unittest.TestCase):
         self.assertTrue(s.compatible_with(length))
 
     def test_redefined_unit_makes_incompatible(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         meter = s.units["meter"]
         rebadged = _Unit(
@@ -223,7 +221,6 @@ class TestCompatibleWith(unittest.TestCase):
         self.assertFalse(other.compatible_with(s))
 
     def test_disagreeing_conversion_edge_makes_incompatible(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         length = s.dimensions["length"]
         a = _Unit(name="ucon_rel_compat_a", dimension=length, aliases=())
@@ -280,7 +277,6 @@ class TestDiff(unittest.TestCase):
         self.assertEqual(d.units.removed, frozenset())
 
     def test_diff_redefined_when_unit_replaced(self):
-        from ucon.core import Unit as _Unit
         s = _active()
         meter = s.units["meter"]
         rebadged = _Unit(

--- a/tests/ucon/test_base_form.py
+++ b/tests/ucon/test_base_form.py
@@ -26,6 +26,8 @@ import pytest
 from ucon import Scale, Number, Ratio
 from ucon import units
 from ucon.core import BaseForm, UnitProduct, UnitFactor
+from ucon import graph as graph_mod
+from ucon.core import Unit
 
 
 # -----------------------------------------------------------------------
@@ -41,19 +43,16 @@ class TestNoGraphInit:
     """
 
     def test_kilogram_base_form_no_graph(self, monkeypatch):
-        from ucon import graph as graph_mod
         monkeypatch.setattr(graph_mod, '_default_graph', None, raising=False)
         assert units.kilogram.base_form is not None
         assert units.kilogram.base_form.prefactor == 1.0
 
     def test_canonical_magnitude_no_graph(self, monkeypatch):
-        from ucon import graph as graph_mod
         monkeypatch.setattr(graph_mod, '_default_graph', None, raising=False)
         n = units.gram(1000)
         assert abs(n._canonical_magnitude - 1.0) < 1e-12
 
     def test_arithmetic_no_graph(self, monkeypatch):
-        from ucon import graph as graph_mod
         monkeypatch.setattr(graph_mod, '_default_graph', None, raising=False)
         n = units.newton(1)
         d = (Scale.kilo * units.gram * units.meter / units.second ** 2)(1)
@@ -155,7 +154,6 @@ class TestBaseFormField:
         assert abs(bf.prefactor - 1.0) < 1e-12
 
     def test_dimensionless_unit_has_no_base_form(self):
-        from ucon.core import Unit
         u = Unit()
         assert u.base_form is None
 

--- a/tests/ucon/test_cache.py
+++ b/tests/ucon/test_cache.py
@@ -24,6 +24,38 @@ from ucon._cache import (
     write_cached_graph,
 )
 from ucon.conversion import Graph
+from ucon.core._types import _get_numpy as _types_get_numpy
+from ucon.maps import _get_numpy as _maps_get_numpy
+from ucon import units
+from ucon._cache import _deserialize_product_tuple_key
+from ucon._cache import _deserialize_product_tuple_key, _serialize_product_key
+from ucon._cache import _fraction_to_prim, _prim_to_fraction
+from ucon._cache import _map_to_prim, _prim_to_map
+from ucon._cache import _prim_to_fraction
+from ucon._cache import _prim_to_map
+from ucon._cache import _resolve_unit_ref, _unit_ref
+from ucon.aspects.types import AspectRule
+from ucon.contexts import ContextEdge, ConversionContext
+from ucon.core import NumberArray
+from ucon.core import NumberArray, Unit
+from ucon.core import Scale, Unit
+from ucon.core import Scale, Unit, UnitFactor
+from ucon.core import Scale, Unit, UnitFactor, UnitProduct
+from ucon.core import Unit
+from ucon.dimension import LENGTH
+from ucon.dimension import LENGTH, MASS
+from ucon.dimension import LENGTH, TIME
+from ucon.maps import AffineMap
+from ucon.maps import AffineMap, ComposedMap, LinearMap
+from ucon.maps import ExpMap
+from ucon.maps import LinearMap
+from ucon.maps import LogMap
+from ucon.maps import Map
+from ucon.maps import ReciprocalMap
+from ucon.maps import _is_array
+from ucon.serialization import FORMAT_VERSION
+from ucon.serialization import FORMAT_VERSION, from_toml
+from ucon.serialization import from_toml
 
 
 TOML_PATH = Path(__file__).resolve().parent.parent.parent / "ucon" / "comprehensive.ucon.toml"
@@ -34,7 +66,6 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_roundtrip_unit_count(self):
         """Unit registries match after round-trip."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -47,7 +78,6 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_roundtrip_edge_count(self):
         """Edge counts match after round-trip."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -69,7 +99,6 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_roundtrip_product_edge_count(self):
         """Product edge counts match."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -81,7 +110,6 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_roundtrip_constants(self):
         """Constant count matches."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -94,7 +122,6 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_roundtrip_kinds(self):
         """Kind lattice count matches."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -107,7 +134,6 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_roundtrip_rebased(self):
         """Rebased unit count matches."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -119,7 +145,6 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_conversion_after_roundtrip(self):
         """Conversions produce correct results from cached graph."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -150,7 +175,6 @@ class TestCacheIO(unittest.TestCase):
         import tempfile
         import shutil
 
-        from ucon.serialization import from_toml
 
         tmpdir = Path(tempfile.mkdtemp())
         try:
@@ -179,7 +203,6 @@ class TestCacheIO(unittest.TestCase):
         import shutil
         import time
 
-        from ucon.serialization import from_toml
 
         tmpdir = Path(tempfile.mkdtemp())
         try:
@@ -249,7 +272,6 @@ class TestEnvDisable(unittest.TestCase):
 
     def test_env_disables_write(self):
         """write_cached_graph returns False when disabled."""
-        from ucon.serialization import from_toml
 
         graph = from_toml(TOML_PATH)
         with mock.patch.dict(os.environ, {"UCON_NO_CACHE": "1"}):
@@ -265,7 +287,6 @@ class TestHeaderValidation(unittest.TestCase):
         import shutil
         import sys as _sys
 
-        from ucon.serialization import FORMAT_VERSION, from_toml
 
         toml_copy = tmpdir / "test.ucon.toml"
         shutil.copy2(TOML_PATH, toml_copy)
@@ -383,8 +404,6 @@ class TestMapCodecCoverage(unittest.TestCase):
     """Codec coverage for all Map types."""
 
     def test_linear_map_roundtrip(self):
-        from ucon._cache import _map_to_prim, _prim_to_map
-        from ucon.maps import LinearMap
 
         m = LinearMap(a=2.54, rel_uncertainty=0.001)
         prim = _map_to_prim(m)
@@ -393,8 +412,6 @@ class TestMapCodecCoverage(unittest.TestCase):
         self.assertAlmostEqual(restored.rel_uncertainty, 0.001)
 
     def test_affine_map_roundtrip(self):
-        from ucon._cache import _map_to_prim, _prim_to_map
-        from ucon.maps import AffineMap
 
         m = AffineMap(a=1.8, b=32.0, rel_uncertainty=0.0)
         prim = _map_to_prim(m)
@@ -403,8 +420,6 @@ class TestMapCodecCoverage(unittest.TestCase):
         self.assertAlmostEqual(restored.b, 32.0)
 
     def test_log_map_roundtrip(self):
-        from ucon._cache import _map_to_prim, _prim_to_map
-        from ucon.maps import LogMap
 
         m = LogMap(scale=20.0, base=10.0, reference=1e-12, offset=0.0)
         prim = _map_to_prim(m)
@@ -414,8 +429,6 @@ class TestMapCodecCoverage(unittest.TestCase):
         self.assertAlmostEqual(restored.reference, 1e-12)
 
     def test_exp_map_roundtrip(self):
-        from ucon._cache import _map_to_prim, _prim_to_map
-        from ucon.maps import ExpMap
 
         m = ExpMap(scale=0.05, base=10.0, reference=1e-12, offset=0.0)
         prim = _map_to_prim(m)
@@ -424,8 +437,6 @@ class TestMapCodecCoverage(unittest.TestCase):
         self.assertAlmostEqual(restored.base, 10.0)
 
     def test_reciprocal_map_roundtrip(self):
-        from ucon._cache import _map_to_prim, _prim_to_map
-        from ucon.maps import ReciprocalMap
 
         m = ReciprocalMap(a=1000.0, rel_uncertainty=0.002)
         prim = _map_to_prim(m)
@@ -434,8 +445,6 @@ class TestMapCodecCoverage(unittest.TestCase):
         self.assertAlmostEqual(restored.rel_uncertainty, 0.002)
 
     def test_composed_map_roundtrip(self):
-        from ucon._cache import _map_to_prim, _prim_to_map
-        from ucon.maps import AffineMap, ComposedMap, LinearMap
 
         inner = LinearMap(a=2.0)
         outer = AffineMap(a=1.5, b=10.0)
@@ -448,8 +457,6 @@ class TestMapCodecCoverage(unittest.TestCase):
         self.assertAlmostEqual(restored.outer.b, 10.0)
 
     def test_unknown_map_type_raises(self):
-        from ucon._cache import _map_to_prim, _prim_to_map
-        from ucon.maps import Map
 
         class FakeMap(Map):
             def __call__(self, x): return x
@@ -459,7 +466,6 @@ class TestMapCodecCoverage(unittest.TestCase):
             _map_to_prim(FakeMap())
 
     def test_unknown_prim_type_raises(self):
-        from ucon._cache import _prim_to_map
 
         with self.assertRaises(ValueError):
             _prim_to_map({"_t": "UNKNOWN"})
@@ -469,42 +475,35 @@ class TestLazyNumpy(unittest.TestCase):
     """Lazy numpy accessor defers import."""
 
     def test_get_numpy_returns_module_when_available(self):
-        from ucon.core._types import _get_numpy
 
-        np = _get_numpy()
+        np = _types_get_numpy()
         # numpy is installed in the test env
         self.assertIsNotNone(np)
         self.assertEqual(np.__name__, "numpy")
 
     def test_get_numpy_caches_result(self):
-        from ucon.core._types import _get_numpy
 
-        first = _get_numpy()
-        second = _get_numpy()
+        first = _types_get_numpy()
+        second = _types_get_numpy()
         self.assertIs(first, second)
 
     def test_maps_get_numpy_returns_module(self):
-        from ucon.maps import _get_numpy
 
-        np = _get_numpy()
+        np = _maps_get_numpy()
         self.assertIsNotNone(np)
         self.assertEqual(np.__name__, "numpy")
 
     def test_is_array_with_ndarray(self):
         import numpy as np
-        from ucon.maps import _is_array
 
         self.assertTrue(_is_array(np.array([1, 2, 3])))
 
     def test_is_array_with_list(self):
-        from ucon.maps import _is_array
 
         self.assertFalse(_is_array([1, 2, 3]))
 
     def test_number_array_still_works(self):
         """NumberArray construction works with lazy numpy."""
-        from ucon.core import NumberArray, Unit
-        from ucon.dimension import LENGTH
 
         u = Unit(name="_test_lazy_np", dimension=LENGTH)
         arr = NumberArray(quantities=[1.0, 2.0, 3.0], unit=u)
@@ -512,12 +511,9 @@ class TestLazyNumpy(unittest.TestCase):
 
     def test_unit_call_with_list_returns_number_array(self):
         """Unit.__call__ with list delegates to NumberArray via lazy numpy."""
-        from ucon.core import Unit
-        from ucon.dimension import LENGTH
 
         u = Unit(name="_test_lazy_np_call", dimension=LENGTH)
         result = u([1.0, 2.0])
-        from ucon.core import NumberArray
         self.assertIsInstance(result, NumberArray)
 
 
@@ -526,7 +522,6 @@ class TestCacheFirstLoading(unittest.TestCase):
 
     def test_units_module_has_meter(self):
         """Basic sanity: units loaded (from cache or TOML)."""
-        from ucon import units
 
         self.assertTrue(hasattr(units, "meter"))
         self.assertEqual(units.meter.name, "meter")
@@ -536,7 +531,6 @@ class TestCacheFirstLoading(unittest.TestCase):
         cache_path = TOML_PATH.with_suffix(".cache")
         # The cache is written on first import if missing.
         # In CI or fresh env, it may not exist yet — trigger write.
-        from ucon.serialization import from_toml
 
         graph = from_toml(TOML_PATH)
         write_cached_graph(graph, TOML_PATH)
@@ -547,9 +541,6 @@ class TestProductKeySerialization(unittest.TestCase):
     """Coverage for _serialize_product_key / _deserialize_product_tuple_key."""
 
     def test_product_key_roundtrip(self):
-        from ucon._cache import _deserialize_product_tuple_key, _serialize_product_key
-        from ucon.core import Scale, Unit, UnitFactor
-        from ucon.dimension import LENGTH, MASS
 
         meter = Unit(name="meter", dimension=LENGTH)
         kg = Unit(name="kilogram", dimension=MASS)
@@ -568,7 +559,6 @@ class TestProductKeySerialization(unittest.TestCase):
         self.assertEqual(restored[1][0], "kilogram")
 
     def test_product_key_missing_unit_returns_none(self):
-        from ucon._cache import _deserialize_product_tuple_key
 
         ser = [("nonexistent", "LENGTH", "one", 1)]
         result = _deserialize_product_tuple_key(ser, {})
@@ -579,9 +569,6 @@ class TestUnitRefCodec(unittest.TestCase):
     """Coverage for _unit_ref / _resolve_unit_ref with UnitProduct."""
 
     def test_unit_ref_plain_unit(self):
-        from ucon._cache import _resolve_unit_ref, _unit_ref
-        from ucon.core import Unit
-        from ucon.dimension import LENGTH
 
         meter = Unit(name="meter", dimension=LENGTH)
         ref = _unit_ref(meter)
@@ -593,9 +580,6 @@ class TestUnitRefCodec(unittest.TestCase):
         self.assertIs(restored, meter)
 
     def test_unit_ref_unit_product(self):
-        from ucon._cache import _resolve_unit_ref, _unit_ref
-        from ucon.core import Scale, Unit, UnitFactor, UnitProduct
-        from ucon.dimension import LENGTH, TIME
 
         meter = Unit(name="meter", dimension=LENGTH)
         second = Unit(name="second", dimension=TIME)
@@ -617,7 +601,6 @@ class TestContextRoundTrip(unittest.TestCase):
 
     def test_contexts_preserved(self):
         """If the graph has contexts, they survive cache round-trip."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         if not original._contexts:
@@ -643,7 +626,6 @@ class TestWriteFailurePath(unittest.TestCase):
         import tempfile
         import shutil
 
-        from ucon.serialization import from_toml
 
         tmpdir = Path(tempfile.mkdtemp())
         try:
@@ -665,7 +647,6 @@ class TestFractionCodec(unittest.TestCase):
     def test_fraction_roundtrip(self):
         from fractions import Fraction
 
-        from ucon._cache import _fraction_to_prim, _prim_to_fraction
 
         # Standard fraction
         f = Fraction(3, 7)
@@ -676,7 +657,6 @@ class TestFractionCodec(unittest.TestCase):
     def test_integer_as_fraction(self):
         from fractions import Fraction
 
-        from ucon._cache import _prim_to_fraction
 
         # Plain int (as stored for integer-valued vector components)
         restored = _prim_to_fraction(5)
@@ -688,7 +668,6 @@ class TestFormulaCodec(unittest.TestCase):
 
     def test_formula_roundtrip(self):
         """Formulas survive _to_primitives → _from_primitives on the full graph."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -708,12 +687,10 @@ class TestFormulaCodec(unittest.TestCase):
         self.assertEqual(set(rt.input_kinds.keys()), {"D", "w_R"})
         self.assertTrue(rt.commutative)
 
-        from ucon.aspects.types import AspectRule
         self.assertEqual(rt.aspect_rules["w_R"], AspectRule.CONSUME)
 
     def test_formula_missing_input_kind_skipped(self):
         """Formula with unknown input kind is silently dropped."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -731,7 +708,6 @@ class TestFormulaCodec(unittest.TestCase):
 
     def test_formula_missing_output_kind_skipped(self):
         """Formula with unknown output kind is silently dropped."""
-        from ucon.serialization import from_toml
 
         original = from_toml(TOML_PATH)
         raw = _to_primitives(original)
@@ -771,7 +747,6 @@ class TestFormulaCodec(unittest.TestCase):
         import shutil
         import tempfile
 
-        from ucon.serialization import from_toml
 
         tmpdir = Path(tempfile.mkdtemp())
         try:
@@ -804,7 +779,6 @@ class TestNonDictPayload(unittest.TestCase):
         import sys as _sys
         import tempfile
 
-        from ucon.serialization import FORMAT_VERSION
 
         tmpdir = Path(tempfile.mkdtemp())
         try:
@@ -838,7 +812,6 @@ class TestWriteOsReplaceFailure(unittest.TestCase):
         import shutil
         import tempfile
 
-        from ucon.serialization import from_toml
 
         tmpdir = Path(tempfile.mkdtemp())
         try:
@@ -863,7 +836,6 @@ class TestFractionFromString(unittest.TestCase):
     def test_fraction_from_string(self):
         from fractions import Fraction
 
-        from ucon._cache import _prim_to_fraction
 
         result = _prim_to_fraction("3/7")
         self.assertEqual(result, Fraction(3, 7))
@@ -871,7 +843,6 @@ class TestFractionFromString(unittest.TestCase):
     def test_fraction_from_decimal_string(self):
         from fractions import Fraction
 
-        from ucon._cache import _prim_to_fraction
 
         result = _prim_to_fraction("0.5")
         self.assertEqual(result, Fraction(1, 2))
@@ -881,9 +852,6 @@ class TestProductTupleKeyUnknownScale(unittest.TestCase):
     """_deserialize_product_tuple_key falls back to Scale.one for unknown scales."""
 
     def test_unknown_scale_defaults_to_one(self):
-        from ucon._cache import _deserialize_product_tuple_key
-        from ucon.core import Scale, Unit
-        from ucon.dimension import LENGTH
 
         meter = Unit(name="meter", dimension=LENGTH)
         unit_map = {"meter": meter}
@@ -900,10 +868,6 @@ class TestContextCodecPrimitives(unittest.TestCase):
 
     def test_context_codec_roundtrip(self):
         """ConversionContext survives _to_primitives → _from_primitives."""
-        from ucon.contexts import ContextEdge, ConversionContext
-        from ucon.core import Unit
-        from ucon.dimension import LENGTH
-        from ucon.maps import LinearMap
 
         meter = Unit(name="meter", dimension=LENGTH)
         foot = Unit(name="foot", dimension=LENGTH)

--- a/tests/ucon/test_constants.py
+++ b/tests/ucon/test_constants.py
@@ -9,6 +9,10 @@ import pytest
 
 from ucon import Constant, Number, units, constants
 from ucon.dimension import Dimension
+from ucon import Constant
+from ucon import constants
+from ucon.constants import all_constants
+from ucon.constants import get_constant_by_symbol
 
 
 class TestConstantClass:
@@ -392,14 +396,12 @@ class TestConstantEnumeration:
 
     def test_all_constants_returns_26(self):
         """all_constants() returns list of 26 constants."""
-        from ucon.constants import all_constants
         result = all_constants()
         assert len(result) == 26
         assert all(isinstance(c, Constant) for c in result)
 
     def test_all_constants_categories(self):
         """all_constants() includes all three categories."""
-        from ucon.constants import all_constants
         cats = {c.category for c in all_constants()}
         assert "exact" in cats
         assert "derived" in cats
@@ -407,39 +409,33 @@ class TestConstantEnumeration:
 
     def test_get_constant_by_symbol_direct(self):
         """get_constant_by_symbol() finds by direct symbol."""
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("c")
         assert c is not None
         assert c.name == "speed of light in vacuum"
 
     def test_get_constant_by_symbol_unicode_alias(self):
         """get_constant_by_symbol() finds via unicode alias map."""
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("k_B")
         assert c is not None
         assert c.symbol == "k"
 
     def test_get_constant_by_symbol_ascii_alias(self):
         """get_constant_by_symbol() finds via ASCII alias map."""
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("hbar")
         assert c is not None
         assert c.symbol == "\u210f"
 
     def test_get_constant_by_symbol_not_found(self):
         """get_constant_by_symbol() returns None for unknown."""
-        from ucon.constants import get_constant_by_symbol
         assert get_constant_by_symbol("NONEXISTENT") is None
 
     def test_get_constant_by_symbol_all_unicode(self):
         """All documented unicode aliases resolve."""
-        from ucon.constants import get_constant_by_symbol
         for sym in ['c', 'h', 'e', 'G', 'R', 'NA', 'N_A', 'k']:
             assert get_constant_by_symbol(sym) is not None, f"Failed for {sym!r}"
 
     def test_get_constant_by_symbol_all_ascii(self):
         """All documented ASCII aliases resolve."""
-        from ucon.constants import get_constant_by_symbol
         for sym in ['hbar', 'alpha', 'epsilon_0', 'mu_0', 'm_e', 'm_p', 'm_n']:
             assert get_constant_by_symbol(sym) is not None, f"Failed for {sym!r}"
 
@@ -483,11 +479,9 @@ class TestModuleExports:
 
     def test_constant_exported_from_ucon(self):
         """Constant class is exported from ucon."""
-        from ucon import Constant
         assert Constant is not None
 
     def test_constants_module_exported(self):
         """constants module is exported from ucon."""
-        from ucon import constants
         assert constants is not None
         assert hasattr(constants, 'speed_of_light')

--- a/tests/ucon/test_contexts.py
+++ b/tests/ucon/test_contexts.py
@@ -15,6 +15,11 @@ from ucon.contexts import (
 )
 from ucon.graph import get_default_graph
 from ucon.maps import LinearMap, ReciprocalMap
+from ucon import contexts
+from ucon.contexts import boltzmann
+from ucon.contexts import spectroscopy
+from ucon.contexts import spectroscopy, boltzmann
+from ucon.graph import DimensionMismatch
 
 
 class TestContextEdge(unittest.TestCase):
@@ -70,7 +75,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_spectroscopy_wavelength_to_frequency(self):
         """Wavelength -> frequency via c = lambda * f."""
-        from ucon.contexts import spectroscopy
         wavelength_m = 500e-9  # 500 nm
         expected_freq = 299792458.0 / wavelength_m
 
@@ -82,7 +86,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_spectroscopy_frequency_to_wavelength(self):
         """Frequency -> wavelength (inverse direction)."""
-        from ucon.contexts import spectroscopy
         freq = 5e14
         expected_wavelength = 299792458.0 / freq
 
@@ -93,7 +96,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_spectroscopy_frequency_to_energy(self):
         """Frequency -> energy via E = h * f."""
-        from ucon.contexts import spectroscopy
         freq = 5e14
         h = 6.62607015e-34
         expected_energy = h * freq
@@ -105,7 +107,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_boltzmann_temperature_to_energy(self):
         """Temperature -> energy via E = k_B * T."""
-        from ucon.contexts import boltzmann
         temp = 300.0
         k_B = 1.380649e-23
         expected_energy = k_B * temp
@@ -117,7 +118,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_boltzmann_energy_to_temperature(self):
         """Energy -> temperature (inverse)."""
-        from ucon.contexts import boltzmann
         k_B = 1.380649e-23
         energy = 4.14e-21  # ~300K
 
@@ -129,7 +129,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_multiple_contexts(self):
         """Multiple contexts compose in one using_context() call."""
-        from ucon.contexts import spectroscopy, boltzmann
 
         with using_context(spectroscopy, boltzmann):
             # Both spectroscopy and boltzmann edges should be available
@@ -141,8 +140,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_graph_restored_after_exit(self):
         """Original graph is unmodified after context exits."""
-        from ucon.contexts import spectroscopy
-        from ucon.graph import DimensionMismatch
 
         with using_context(spectroscopy):
             # Should work inside context
@@ -154,7 +151,6 @@ class TestUsingContext(unittest.TestCase):
 
     def test_yields_extended_graph(self):
         """using_context() yields the extended graph."""
-        from ucon.contexts import spectroscopy
 
         with using_context(spectroscopy) as graph:
             self.assertIsNotNone(graph)
@@ -168,7 +164,6 @@ class TestLazySingletons(unittest.TestCase):
 
     def test_spectroscopy_is_cached(self):
         """Subsequent accesses return the same object."""
-        from ucon import contexts
         s1 = contexts.spectroscopy
         s2 = contexts.spectroscopy
         self.assertIs(s1, s2)
@@ -176,7 +171,6 @@ class TestLazySingletons(unittest.TestCase):
 
     def test_boltzmann_is_cached(self):
         """Subsequent accesses return the same object."""
-        from ucon import contexts
         b1 = contexts.boltzmann
         b2 = contexts.boltzmann
         self.assertIs(b1, b2)
@@ -184,7 +178,6 @@ class TestLazySingletons(unittest.TestCase):
 
     def test_unknown_attr_raises(self):
         """Accessing unknown attribute raises AttributeError."""
-        from ucon import contexts
         with self.assertRaises(AttributeError):
             _ = contexts.nonexistent_context
 

--- a/tests/ucon/test_core.py
+++ b/tests/ucon/test_core.py
@@ -16,6 +16,7 @@ from ucon.basis import Vector
 from ucon.core import UnitFactor, UnitProduct, _ScaleDescriptor
 from ucon.dimension import all_dimensions, resolve, SI
 from fractions import Fraction
+from ucon.basis.builtin import SI
 
 
 class TestDimension(unittest.TestCase):
@@ -24,7 +25,6 @@ class TestDimension(unittest.TestCase):
         # Group non-pseudo dimensions by basis and verify uniqueness within
         # each SI partition. CGS-ESU legitimately has degenerate dimensions
         # (e.g., charge and magnetic flux share the same vector).
-        from ucon.basis.builtin import SI
         seen = set()
         for dim in all_dimensions():
             if dim.is_pseudo:
@@ -269,7 +269,6 @@ class TestDimensionEdgeCases(unittest.TestCase):
         # Hashes should be unique per distinct dimension (including pseudo-dimensions)
         # CGS-ESU has legitimate dimensional degeneracies (e.g., charge == magnetic_flux)
         # so we check uniqueness within SI only, and verify all dims are hashable.
-        from ucon.basis.builtin import SI
         dims = all_dimensions()
         # Verify each dimension can be used in a set (hashable)
         dim_set = set(dims)

--- a/tests/ucon/test_core_extended.py
+++ b/tests/ucon/test_core_extended.py
@@ -3,6 +3,8 @@ import unittest
 
 from ucon import Dimension, units
 from ucon.core import Exponent, Scale, _ScaleDescriptor, UnitFactor, UnitProduct
+from ucon import Number
+from ucon import Number, units
 
 
 # ---------------------------------------------------------------------------
@@ -55,7 +57,6 @@ class TestScaleExtended(unittest.TestCase):
 class TestNumberExtended(unittest.TestCase):
 
     def test_number_equality_scaled_units(self):
-        from ucon import Number, units
 
         km = Scale.kilo * units.meter
         n1 = Number(unit=km, quantity=1)
@@ -64,12 +65,10 @@ class TestNumberExtended(unittest.TestCase):
         self.assertEqual(n1, n2)
 
     def test_number_equality_dimension_mismatch(self):
-        from ucon import Number, units
         n1 = Number(unit=units.meter, quantity=1)
         n2 = Number(unit=units.second, quantity=1)
         self.assertNotEqual(n1, n2)
 
     def test_number_eq_raises_for_bad_type(self):
-        from ucon import Number
         with self.assertRaises(TypeError):
             _ = Number(unit=UnitFactor("m", dimension=Dimension.length), quantity=1) == 10

--- a/tests/ucon/test_dimension.py
+++ b/tests/ucon/test_dimension.py
@@ -11,6 +11,10 @@ from fractions import Fraction
 from ucon.dimension import Dimension, resolve, basis, SI
 from ucon.basis import Basis, BasisComponent, BasisGraph, Vector
 from ucon.system import active_system, use
+from ucon import parse_dimension
+from ucon.basis.builtin import CGS
+from ucon.system import active_system
+import ucon.dimension as dim_mod
 
 
 class TestDimensionConstruction(unittest.TestCase):
@@ -180,7 +184,6 @@ class TestDimensionAlgebraOpsRouting(unittest.TestCase):
     def test_cross_basis_multiplication_routes_via_ops(self):
         """SI length * CGS length yields an area-shaped dimension via
         graph-mediated projection."""
-        from ucon.basis.builtin import CGS
 
         si_length = Dimension.length
         cgs_length = Dimension.from_components(CGS, length=1)
@@ -197,7 +200,6 @@ class TestDimensionAlgebraOpsRouting(unittest.TestCase):
     def test_cross_basis_division_routes_via_ops(self):
         """SI length / CGS time yields a velocity-shaped dimension via
         graph-mediated projection."""
-        from ucon.basis.builtin import CGS
 
         si_length = Dimension.length
         cgs_time = Dimension.from_components(CGS, time=1)
@@ -278,7 +280,6 @@ class TestDimensionAlgebraCacheKeying(unittest.TestCase):
         """
         import gc
 
-        from ucon import parse_dimension
 
         self.assertEqual(parse_dimension("L^2"), Dimension.area)
         gc.collect()  # encourage id reuse for the next parse
@@ -297,14 +298,12 @@ class TestDimensionAlgebraCacheRouting(unittest.TestCase):
 
     def test_default_state_populates_active_system_cache(self):
         """v1.11: With eager init, algebra always routes through the active system cache."""
-        from ucon.system import active_system
         cache = active_system()._algebra_cache
         cache.clear()
         _ = Dimension.length * Dimension.time
         self.assertGreater(len(cache.mul), 0)
 
     def test_use_block_routes_to_system_cache(self):
-        from ucon.system import active_system, use
         system = active_system()
         system._algebra_cache.clear()
         with use(system):
@@ -316,7 +315,6 @@ class TestDimensionAlgebraCacheRouting(unittest.TestCase):
         self.assertGreater(len(system._algebra_cache.pow), 0)
 
     def test_unknown_module_attribute_still_raises(self):
-        import ucon.dimension as dim_mod
         with self.assertRaises(AttributeError):
             dim_mod._DIM_NOT_A_CACHE
 
@@ -505,7 +503,6 @@ class TestDimensionRepr(unittest.TestCase):
 
     def test_repr_unnamed_dimension_falls_back_to_vector(self):
         """Dimensions constructed without a name repr as their vector."""
-        from ucon.basis.builtin import CGS
 
         # A CGS-basis dimension is not in the SI _REGISTRY and is created
         # without a ``name``, exercising the ``__repr__`` fallback branch.

--- a/tests/ucon/test_factor_uncertainty.py
+++ b/tests/ucon/test_factor_uncertainty.py
@@ -12,6 +12,18 @@ import math
 import unittest
 
 from ucon.maps import AffineMap, ComposedMap, LinearMap, ReciprocalMap
+from ucon import units
+from ucon import units, Scale
+from ucon.constants import get_constant_by_symbol
+from ucon.core import Number
+from ucon.core import Unit
+from ucon.dimension import Dimension
+from ucon.graph import ConversionGraph
+from ucon.graph import get_default_graph
+from ucon.packages import EdgeDef
+from ucon.packages import _build_map
+from ucon.serialization import _build_edge_map
+from ucon.serialization import _edge_dict
 
 
 class TestLinearMapRelUncertainty(unittest.TestCase):
@@ -148,9 +160,6 @@ class TestMultiHopAccumulation(unittest.TestCase):
     """Composed uncertainty over multi-hop graph paths."""
 
     def test_three_hop_quadrature(self):
-        from ucon.graph import ConversionGraph
-        from ucon.core import Unit
-        from ucon.dimension import Dimension
 
         graph = ConversionGraph()
         # Create a chain: A -> B -> C -> D with uncertainties
@@ -179,18 +188,14 @@ class TestNumberToBackwardCompat(unittest.TestCase):
     """Number.to() without propagate_factor_uncertainty is unchanged."""
 
     def test_default_no_uncertainty(self):
-        from ucon import units
         result = units.joule(1).to(units.hartree)
         self.assertIsNone(result.uncertainty)
 
     def test_exact_conversion_no_uncertainty(self):
-        from ucon import units
         result = units.meter(1).to(units.foot)
         self.assertIsNone(result.uncertainty)
 
     def test_measurement_uncertainty_still_propagates(self):
-        from ucon import units
-        from ucon.core import Number
         n = Number(quantity=1.0, unit=units.meter, uncertainty=0.01)
         result = n.to(units.foot)
         self.assertIsNotNone(result.uncertainty)
@@ -201,21 +206,17 @@ class TestNumberToWithFactorUncertainty(unittest.TestCase):
     """Number.to() with propagate_factor_uncertainty=True."""
 
     def test_exact_edge_no_uncertainty(self):
-        from ucon import units
         # meter → foot is exact, should produce no uncertainty
         result = units.meter(1).to(units.foot, propagate_factor_uncertainty=True)
         self.assertIsNone(result.uncertainty)
 
     def test_measured_edge_produces_uncertainty(self):
-        from ucon import units
         # joule → hartree uses Eh which has uncertainty
         result = units.joule(1).to(units.hartree, propagate_factor_uncertainty=True)
         self.assertIsNotNone(result.uncertainty)
         self.assertGreater(result.uncertainty, 0)
 
     def test_input_with_measurement_and_factor_uncertainty(self):
-        from ucon import units
-        from ucon.core import Number
         n = Number(quantity=1.0, unit=units.joule, uncertainty=1e-10)
         result = n.to(units.hartree, propagate_factor_uncertainty=True)
         self.assertIsNotNone(result.uncertainty)
@@ -224,7 +225,6 @@ class TestNumberToWithFactorUncertainty(unittest.TestCase):
         self.assertGreater(result.uncertainty, result_meas_only.uncertainty)
 
     def test_planck_units_have_uncertainty(self):
-        from ucon import units
         result = units.kilogram(1).to(units.planck_mass, propagate_factor_uncertainty=True)
         self.assertIsNotNone(result.uncertainty)
         self.assertGreater(result.uncertainty, 0)
@@ -245,7 +245,6 @@ class TestSerializationRoundTrip(unittest.TestCase):
         self.assertEqual(d["rel_uncertainty"], 1e-5)
 
     def test_roundtrip_via_build_map(self):
-        from ucon.packages import _build_map
         m = LinearMap(3.28, rel_uncertainty=1e-5)
         d = m.to_dict()
         reconstructed = _build_map(d)
@@ -276,7 +275,6 @@ class TestSerializationRoundTrip(unittest.TestCase):
         self.assertEqual(d["rel_uncertainty"], 3e-5)
 
     def test_affine_roundtrip_via_build_map(self):
-        from ucon.packages import _build_map
         m = AffineMap(1.8, 32.0, rel_uncertainty=2e-6)
         d = m.to_dict()
         reconstructed = _build_map(d)
@@ -295,9 +293,6 @@ class TestGeneralPathFactorUncertainty(unittest.TestCase):
 
     def _make_compound_graph(self, rel_unc=2e-5):
         """Build a custom graph with length and time units that carry uncertainty."""
-        from ucon.graph import ConversionGraph
-        from ucon.core import Unit
-        from ucon.dimension import Dimension
 
         graph = ConversionGraph()
         # Two length units and two time units
@@ -314,7 +309,6 @@ class TestGeneralPathFactorUncertainty(unittest.TestCase):
 
     def test_general_path_with_custom_graph(self):
         """Multi-factor UnitProduct propagates factor uncertainty via general path."""
-        from ucon.core import Number
 
         graph, L1, L2, T1, T2 = self._make_compound_graph(rel_unc=2e-5)
         # len_a / time_a → len_b / time_b (two-factor UnitProduct)
@@ -327,7 +321,6 @@ class TestGeneralPathFactorUncertainty(unittest.TestCase):
 
     def test_general_path_default_no_uncertainty(self):
         """Default (no flag) produces no uncertainty on general path."""
-        from ucon.core import Number
 
         graph, L1, L2, T1, T2 = self._make_compound_graph(rel_unc=2e-5)
         src_unit = L1 / T1
@@ -338,7 +331,6 @@ class TestGeneralPathFactorUncertainty(unittest.TestCase):
 
     def test_general_path_combined_measurement_and_factor(self):
         """General path combines measurement + factor uncertainty via quadrature."""
-        from ucon.core import Number
 
         graph, L1, L2, T1, T2 = self._make_compound_graph(rel_unc=2e-5)
         src_unit = L1 / T1
@@ -353,8 +345,6 @@ class TestGeneralPathFactorUncertainty(unittest.TestCase):
 
     def test_exact_composite_conversion_no_uncertainty(self):
         """Exact composite conversion produces no uncertainty even with flag."""
-        from ucon import units, Scale
-        from ucon.core import Number
 
         # km/h → m/s is exact (no measured constants)
         km = Scale.kilo * units.meter
@@ -365,7 +355,6 @@ class TestGeneralPathFactorUncertainty(unittest.TestCase):
 
     def test_general_path_exact_edge_no_uncertainty(self):
         """Exact multi-factor edge produces no uncertainty even with flag."""
-        from ucon.core import Number
 
         graph, L1, L2, T1, T2 = self._make_compound_graph(rel_unc=0.0)
         src_unit = L1 / T1
@@ -376,7 +365,6 @@ class TestGeneralPathFactorUncertainty(unittest.TestCase):
 
     def test_general_path_quadrature_accumulates(self):
         """Multi-factor general path accumulates uncertainty from each factor."""
-        from ucon.core import Number
 
         r = 3e-5
         graph, L1, L2, T1, T2 = self._make_compound_graph(rel_unc=r)
@@ -395,32 +383,24 @@ class TestEdgeUncertaintyInDefaultGraph(unittest.TestCase):
 
     def test_exact_edge_has_zero_rel_uncertainty(self):
         """meter → foot edge is exact (no measured constant)."""
-        from ucon import units
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         m = graph.convert(src=units.meter, dst=units.foot)
         self.assertEqual(m.rel_uncertainty, 0.0)
 
     def test_hartree_edge_has_nonzero_rel_uncertainty(self):
         """joule → hartree edge carries Eh uncertainty."""
-        from ucon import units
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         m = graph.convert(src=units.joule, dst=units.hartree)
         self.assertGreater(m.rel_uncertainty, 0)
 
     def test_planck_mass_edge_has_nonzero_rel_uncertainty(self):
         """kg → planck_mass edge carries mP uncertainty."""
-        from ucon import units
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         m = graph.convert(src=units.kilogram, dst=units.planck_mass)
         self.assertGreater(m.rel_uncertainty, 0)
 
     def test_planck_rel_uncertainty_order_of_magnitude(self):
         """Planck constant uncertainties are ~1e-5 (relative)."""
-        from ucon import units
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         m = graph.convert(src=units.kilogram, dst=units.planck_mass)
         self.assertGreater(m.rel_uncertainty, 1e-6)
@@ -428,8 +408,6 @@ class TestEdgeUncertaintyInDefaultGraph(unittest.TestCase):
 
     def test_atomic_rel_uncertainty_order_of_magnitude(self):
         """Atomic constant uncertainties are ~1e-10 (relative)."""
-        from ucon import units
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         m = graph.convert(src=units.joule, dst=units.hartree)
         self.assertGreater(m.rel_uncertainty, 1e-13)
@@ -437,8 +415,6 @@ class TestEdgeUncertaintyInDefaultGraph(unittest.TestCase):
 
     def test_multihop_accumulates_uncertainty(self):
         """Multi-hop path accumulates uncertainty via quadrature."""
-        from ucon import units
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         # Direct: joule → hartree
         direct = graph.convert(src=units.joule, dst=units.hartree)
@@ -457,13 +433,11 @@ class TestRelUncHelperEdgeCases(unittest.TestCase):
 
     def test_exact_constant_returns_zero(self):
         """Constants with uncertainty=None return rel_unc=0."""
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("c")
         self.assertIsNone(c.uncertainty)
 
     def test_measured_constant_returns_positive(self):
         """Constants with uncertainty return positive rel_unc."""
-        from ucon.constants import get_constant_by_symbol
         me = get_constant_by_symbol("mₑ")
         self.assertIsNotNone(me.uncertainty)
         rel = me.uncertainty / abs(me.value)
@@ -474,7 +448,6 @@ class TestTomlSerializationRelUncertainty(unittest.TestCase):
     """TOML serialization round-trip for rel_uncertainty."""
 
     def test_edge_dict_linear_with_uncertainty(self):
-        from ucon.serialization import _edge_dict
         m = LinearMap(2.5, rel_uncertainty=1e-5)
         d = _edge_dict("unit_a", "unit_b", m)
         self.assertEqual(d["src"], "unit_a")
@@ -483,13 +456,11 @@ class TestTomlSerializationRelUncertainty(unittest.TestCase):
         self.assertEqual(d["rel_uncertainty"], 1e-5)
 
     def test_edge_dict_linear_exact(self):
-        from ucon.serialization import _edge_dict
         m = LinearMap(2.5)
         d = _edge_dict("unit_a", "unit_b", m)
         self.assertNotIn("rel_uncertainty", d)
 
     def test_edge_dict_affine_with_uncertainty(self):
-        from ucon.serialization import _edge_dict
         m = AffineMap(1.8, 32.0, rel_uncertainty=2e-6)
         d = _edge_dict("unit_a", "unit_b", m)
         self.assertEqual(d["factor"], 1.8)
@@ -497,13 +468,11 @@ class TestTomlSerializationRelUncertainty(unittest.TestCase):
         self.assertEqual(d["rel_uncertainty"], 2e-6)
 
     def test_edge_dict_affine_exact(self):
-        from ucon.serialization import _edge_dict
         m = AffineMap(1.8, 32.0)
         d = _edge_dict("unit_a", "unit_b", m)
         self.assertNotIn("rel_uncertainty", d)
 
     def test_build_edge_map_with_uncertainty(self):
-        from ucon.serialization import _build_edge_map
         spec = {"factor": 3.28, "rel_uncertainty": 1e-5}
         m = _build_edge_map(spec, None)
         self.assertIsInstance(m, LinearMap)
@@ -511,14 +480,12 @@ class TestTomlSerializationRelUncertainty(unittest.TestCase):
         self.assertAlmostEqual(m.rel_uncertainty, 1e-5)
 
     def test_build_edge_map_without_uncertainty(self):
-        from ucon.serialization import _build_edge_map
         spec = {"factor": 3.28}
         m = _build_edge_map(spec, None)
         self.assertIsInstance(m, LinearMap)
         self.assertEqual(m.rel_uncertainty, 0.0)
 
     def test_build_edge_map_affine_with_uncertainty(self):
-        from ucon.serialization import _build_edge_map
         spec = {"factor": 1.8, "offset": 32.0, "rel_uncertainty": 2e-6}
         m = _build_edge_map(spec, None)
         self.assertIsInstance(m, AffineMap)
@@ -529,24 +496,20 @@ class TestPackagesEdgeDefRelUncertainty(unittest.TestCase):
     """EdgeDef rel_uncertainty in packages.py."""
 
     def test_edge_def_default_zero(self):
-        from ucon.packages import EdgeDef
         e = EdgeDef(src="meter", dst="foot", factor=3.28084)
         self.assertEqual(e.rel_uncertainty, 0.0)
 
     def test_edge_def_with_uncertainty(self):
-        from ucon.packages import EdgeDef
         e = EdgeDef(src="joule", dst="hartree", factor=2.29e17, rel_uncertainty=1.1e-12)
         self.assertEqual(e.rel_uncertainty, 1.1e-12)
 
     def test_edge_def_builds_linear_map_with_uncertainty(self):
-        from ucon.packages import EdgeDef
         e = EdgeDef(src="joule", dst="hartree", factor=2.29e17, rel_uncertainty=1.1e-12)
         m = e._build_edge_map()
         self.assertIsInstance(m, LinearMap)
         self.assertAlmostEqual(m.rel_uncertainty, 1.1e-12)
 
     def test_edge_def_builds_affine_map_with_uncertainty(self):
-        from ucon.packages import EdgeDef
         e = EdgeDef(src="celsius", dst="kelvin", factor=1.0, offset=273.15, rel_uncertainty=1e-8)
         m = e._build_edge_map()
         self.assertIsInstance(m, AffineMap)
@@ -557,43 +520,35 @@ class TestNewConstantsExist(unittest.TestCase):
     """Verify the 8 new measured constants are available."""
 
     def test_hartree_energy(self):
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("Eₕ")
         self.assertIsNotNone(c.uncertainty)
         self.assertEqual(c.category, "measured")
 
     def test_rydberg_energy(self):
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("Ry")
         self.assertIsNotNone(c.uncertainty)
 
     def test_bohr_radius(self):
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("a₀")
         self.assertIsNotNone(c.uncertainty)
 
     def test_planck_mass(self):
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("m_P")
         self.assertIsNotNone(c.uncertainty)
 
     def test_planck_length(self):
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("l_P")
         self.assertIsNotNone(c.uncertainty)
 
     def test_planck_time(self):
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("t_P")
         self.assertIsNotNone(c.uncertainty)
 
     def test_planck_temperature(self):
-        from ucon.constants import get_constant_by_symbol
         c = get_constant_by_symbol("T_P")
         self.assertIsNotNone(c.uncertainty)
 
     def test_ascii_aliases_resolve(self):
-        from ucon.constants import get_constant_by_symbol
         for sym in ["E_h", "a_0", "m_P", "l_P", "t_P", "T_P"]:
             c = get_constant_by_symbol(sym)
             self.assertIsNotNone(c, f"Failed to resolve {sym}")
@@ -604,9 +559,7 @@ class TestQuantitativeUncertaintyPropagation(unittest.TestCase):
 
     def test_factor_only_uncertainty_value(self):
         """Input with no measurement uncertainty → δy = |y| * rel_unc."""
-        from ucon import units
         result = units.joule(1).to(units.hartree, propagate_factor_uncertainty=True)
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         m = graph.convert(src=units.joule, dst=units.hartree)
         expected_unc = abs(result.quantity) * m.rel_uncertainty
@@ -614,9 +567,6 @@ class TestQuantitativeUncertaintyPropagation(unittest.TestCase):
 
     def test_combined_quadrature_value(self):
         """Input with measurement uncertainty → quadrature of both sources."""
-        from ucon import units
-        from ucon.core import Number
-        from ucon.graph import get_default_graph
 
         n = Number(quantity=1.0, unit=units.joule, uncertainty=1e-10)
         result = n.to(units.hartree, propagate_factor_uncertainty=True)
@@ -631,15 +581,12 @@ class TestQuantitativeUncertaintyPropagation(unittest.TestCase):
 
     def test_zero_quantity_no_factor_uncertainty(self):
         """Converting 0.0 with factor uncertainty → no uncertainty (|y|*r = 0)."""
-        from ucon import units
         result = units.joule(0).to(units.hartree, propagate_factor_uncertainty=True)
         # 0 * rel_unc = 0, so uncertainty should be None
         self.assertIsNone(result.uncertainty)
 
     def test_inverse_direction_uncertainty(self):
         """hartree → joule carries same rel_uncertainty as joule → hartree."""
-        from ucon import units
-        from ucon.graph import get_default_graph
         graph = get_default_graph()
         fwd = graph.convert(src=units.joule, dst=units.hartree)
         rev = graph.convert(src=units.hartree, dst=units.joule)

--- a/tests/ucon/test_feedback_verification.py
+++ b/tests/ucon/test_feedback_verification.py
@@ -32,6 +32,8 @@ from ucon.basis import (
 from ucon.basis.builtin import SI
 from ucon.dimension import resolve
 from ucon.system import active_system, use
+from ucon.basis.builtin import CGS, CGS_ESU, NATURAL, PLANCK, ATOMIC
+from ucon.resolver import parse_unit
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +231,6 @@ class TestTriage1BareComponentDimensions:
         either succeeds OR fails with a structured exception (not a crash).
         Run with -v to see which cases land on which side.
         """
-        from ucon.resolver import parse_unit
 
         try:
             result = parse_unit(spec)
@@ -243,7 +244,6 @@ class TestTriage1BareComponentDimensions:
 
     def test_summary_table(self) -> None:
         """Print a registry-shaped summary of all six cases at once."""
-        from ucon.resolver import parse_unit
 
         cases = ["M", "M¹", "M^1", "M·T⁻¹", "mass", "mass^1"]
         rows = []
@@ -275,7 +275,6 @@ class TestTriage1BareComponentDimensions:
 def test_standard_graph_includes_expected_basis_transforms() -> None:
     """Confirm the standard graph wiring is intact under current main."""
     graph = active_system().basis_graph
-    from ucon.basis.builtin import CGS, CGS_ESU, NATURAL, PLANCK, ATOMIC
 
     # SI -> CGS, CGS_ESU, NATURAL, PLANCK, ATOMIC must all be reachable.
     for target in (CGS, CGS_ESU, NATURAL, PLANCK, ATOMIC):

--- a/tests/ucon/test_natural_units.py
+++ b/tests/ucon/test_natural_units.py
@@ -20,6 +20,7 @@ from ucon.basis import (
 )
 from ucon.basis.builtin import NATURAL, SI
 from ucon.basis.transforms import NATURAL_TO_SI, SI_TO_NATURAL
+from ucon.basis import BasisTransform
 
 
 # -----------------------------------------------------------------------------
@@ -431,7 +432,6 @@ class TestConstantBoundBasisTransform:
 
     def test_as_basis_transform(self):
         """GIVEN ConstantBoundBasisTransform, THEN as_basis_transform works."""
-        from ucon.basis import BasisTransform
 
         plain = SI_TO_NATURAL.as_basis_transform()
         assert isinstance(plain, BasisTransform)

--- a/tests/ucon/test_nines.py
+++ b/tests/ucon/test_nines.py
@@ -14,6 +14,7 @@ import unittest
 from ucon import Dimension, units
 from ucon.quantity import Number
 from ucon.graph import DimensionMismatch
+from ucon import parse_unit
 
 
 class TestNinesUnit(unittest.TestCase):
@@ -275,12 +276,10 @@ class TestNinesUnitParsing(unittest.TestCase):
     """Test that nines can be parsed from strings."""
 
     def test_parse_nines(self):
-        from ucon import parse_unit
         unit = parse_unit('nines')
         self.assertEqual(unit, units.nines)
 
     def test_parse_nines_alias(self):
-        from ucon import parse_unit
         unit = parse_unit('9s')
         self.assertEqual(unit, units.nines)
 

--- a/tests/ucon/test_packages.py
+++ b/tests/ucon/test_packages.py
@@ -28,6 +28,13 @@ from ucon import (
 )
 from ucon.graph import ConversionGraph
 from ucon.maps import AffineMap, ExpMap, LinearMap, LogMap, ReciprocalMap
+from ucon.constants import Constant
+from ucon.dimension import ENERGY
+from ucon.kinds import Kind, KindLattice
+from ucon.packages import ConstantDef
+from ucon.packages import _build_map
+from ucon.packages import _parse_factor
+import ucon as ucon_pkg
 
 
 class TestUnitDef(unittest.TestCase):
@@ -395,53 +402,44 @@ class TestParseFactorEdgeCases(unittest.TestCase):
 
     def test_parse_factor_int(self):
         """_parse_factor handles plain int."""
-        from ucon.packages import _parse_factor
         self.assertEqual(_parse_factor(42), 42.0)
 
     def test_parse_factor_float(self):
         """_parse_factor handles plain float."""
-        from ucon.packages import _parse_factor
         self.assertEqual(_parse_factor(3.14), 3.14)
 
     def test_parse_factor_expression_division(self):
         """_parse_factor handles division expression."""
-        from ucon.packages import _parse_factor
         result = _parse_factor("1852 / 3600")
         self.assertAlmostEqual(result, 1852 / 3600)
 
     def test_parse_factor_expression_multiplication(self):
         """_parse_factor handles multiplication expression."""
-        from ucon.packages import _parse_factor
         result = _parse_factor("2 * 3")
         self.assertEqual(result, 6.0)
 
     def test_parse_factor_unary_negation(self):
         """_parse_factor handles unary negation: '-1.5'."""
-        from ucon.packages import _parse_factor
         result = _parse_factor("-1.5")
         self.assertEqual(result, -1.5)
 
     def test_parse_factor_invalid_type_raises(self):
         """_parse_factor raises for non-numeric non-string."""
-        from ucon.packages import _parse_factor
         with self.assertRaises(PackageLoadError):
             _parse_factor([1, 2, 3])
 
     def test_parse_factor_unsupported_op_raises(self):
         """_parse_factor raises for unsupported operator (addition)."""
-        from ucon.packages import _parse_factor
         with self.assertRaises(PackageLoadError):
             _parse_factor("1 + 2")
 
     def test_parse_factor_syntax_error_raises(self):
         """_parse_factor raises for unparseable string."""
-        from ucon.packages import _parse_factor
         with self.assertRaises(PackageLoadError):
             _parse_factor("not a number @#$")
 
     def test_parse_factor_variable_name_raises(self):
         """_parse_factor raises for variable names."""
-        from ucon.packages import _parse_factor
         with self.assertRaises(PackageLoadError):
             _parse_factor("x * y")
 
@@ -458,28 +456,23 @@ class TestConstantFactors(unittest.TestCase):
 
     def test_bare_symbol(self):
         """A factor that is exactly a declared symbol resolves."""
-        from ucon.packages import _parse_factor
         self.assertEqual(_parse_factor("gₙ", self.CONSTANTS), 9.80665)
 
     def test_symbol_in_expression(self):
         """Symbols participate in * and / expressions."""
-        from ucon.packages import _parse_factor
         self.assertAlmostEqual(_parse_factor("1 / gₙ", self.CONSTANTS), 1 / 9.80665)
         self.assertEqual(_parse_factor("c * 2", self.CONSTANTS), 2 * 299792458.0)
 
     def test_nfkc_normalization(self):
         """gₙ inside an expression reaches the AST as 'gn' and still resolves."""
-        from ucon.packages import _parse_factor
         self.assertEqual(_parse_factor("gₙ * 1000", self.CONSTANTS), 9806.65)
 
     def test_alias_resolves(self):
         """Constant aliases resolve like symbols."""
-        from ucon.packages import _parse_factor
         self.assertEqual(_parse_factor("g0", self.CONSTANTS), 9.80665)
 
     def test_non_identifier_symbol_bare_only(self):
         """μ₀ works as the entire factor string but not inside expressions."""
-        from ucon.packages import _parse_factor
         self.assertEqual(_parse_factor("μ₀", self.CONSTANTS), 1.25663706127e-06)
         with self.assertRaises(PackageLoadError) as ctx:
             _parse_factor("2 * μ₀", self.CONSTANTS)
@@ -487,7 +480,6 @@ class TestConstantFactors(unittest.TestCase):
 
     def test_unknown_symbol_names_available(self):
         """An unresolvable symbol errors, listing declared symbols."""
-        from ucon.packages import _parse_factor
         with self.assertRaises(PackageLoadError) as ctx:
             _parse_factor("k_B * 2", self.CONSTANTS)
         self.assertIn('k_B', str(ctx.exception))
@@ -495,7 +487,6 @@ class TestConstantFactors(unittest.TestCase):
 
     def test_no_constants_still_raises(self):
         """Without a constants mapping, symbols raise as before."""
-        from ucon.packages import _parse_factor
         with self.assertRaises(PackageLoadError):
             _parse_factor("gₙ")
 
@@ -540,7 +531,6 @@ factor = "gₙ"
     def test_bundled_catalog_loads(self):
         """Acceptance: ucon's own comprehensive.ucon.toml loads (#279)."""
         import os
-        import ucon as ucon_pkg
         path = os.path.join(
             os.path.dirname(ucon_pkg.__file__), 'comprehensive.ucon.toml')
         pkg = load_package(path)
@@ -718,7 +708,6 @@ class TestConstantDef(unittest.TestCase):
 
     def test_constant_def_creation(self):
         """ConstantDef can be created with valid attributes."""
-        from ucon.packages import ConstantDef
         const_def = ConstantDef(
             symbol='vs',
             name='speed of sound in dry air at 20C',
@@ -734,8 +723,6 @@ class TestConstantDef(unittest.TestCase):
 
     def test_constant_def_materialize(self):
         """ConstantDef.materialize() creates a Constant object."""
-        from ucon.packages import ConstantDef
-        from ucon.constants import Constant
         const_def = ConstantDef(
             symbol='vs',
             name='speed of sound',
@@ -753,7 +740,6 @@ class TestConstantDef(unittest.TestCase):
 
     def test_constant_def_with_uncertainty(self):
         """ConstantDef propagates uncertainty to Constant."""
-        from ucon.packages import ConstantDef
         const_def = ConstantDef(
             symbol='G_local',
             name='local gravitational acceleration',
@@ -772,7 +758,6 @@ class TestConstantDef(unittest.TestCase):
 
     def test_constant_def_unknown_unit_raises(self):
         """ConstantDef.materialize() raises for unknown unit."""
-        from ucon.packages import ConstantDef
         const_def = ConstantDef(
             symbol='x',
             name='unknown',
@@ -824,7 +809,6 @@ category = "exact"
 
     def test_with_package_materializes_constants(self):
         """with_package() materializes constants onto graph."""
-        from ucon.constants import Constant
 
         pkg = UnitPackage(
             name='test_constants',
@@ -846,7 +830,6 @@ category = "exact"
 
     def test_package_constants_accumulate(self):
         """Multiple with_package() calls accumulate constants."""
-        from ucon.packages import ConstantDef
         pkg1 = UnitPackage(
             name='pkg1',
             constants=(
@@ -928,21 +911,18 @@ class TestEdgeDefMapSpec(unittest.TestCase):
 
     def test_map_spec_unknown_type_raises(self):
         """map_spec with unknown type raises PackageLoadError."""
-        from ucon.packages import _build_map
         with self.assertRaises(PackageLoadError) as ctx:
             _build_map({'type': 'quantum'})
         self.assertIn('quantum', str(ctx.exception))
 
     def test_map_spec_missing_type_raises(self):
         """map_spec without type key raises PackageLoadError."""
-        from ucon.packages import _build_map
         with self.assertRaises(PackageLoadError) as ctx:
             _build_map({'scale': 10})
         self.assertIn('type', str(ctx.exception))
 
     def test_map_spec_invalid_params_raises(self):
         """map_spec with invalid constructor params raises PackageLoadError."""
-        from ucon.packages import _build_map
         with self.assertRaises(PackageLoadError):
             _build_map({'type': 'linear', 'nonexistent_param': 5})
 
@@ -1140,8 +1120,6 @@ parent = "energy"
 
     def test_with_package_merges_kinds_into_existing_lattice(self):
         """with_package() merges package kinds into existing graph lattice."""
-        from ucon.kinds import Kind, KindLattice
-        from ucon.dimension import ENERGY
 
         # Build a base lattice with just "energy"
         energy_kind = Kind("energy", dimension=ENERGY)
@@ -1255,7 +1233,6 @@ name = "oops"
         The fix passes the merged kind lattice to materialize() so local
         resolution succeeds.
         """
-        from ucon.packages import ConstantDef
 
         path = self._write_toml('''
 [package]

--- a/tests/ucon/test_quantity.py
+++ b/tests/ucon/test_quantity.py
@@ -8,6 +8,7 @@ from ucon import units
 from ucon.core import UnitProduct, UnitFactor, Scale, Unit
 from ucon import Dimension
 from ucon.quantity import Number, Ratio
+from ucon.units import UnknownUnitError
 
 
 class TestNumber(unittest.TestCase):
@@ -652,7 +653,6 @@ class TestNumberToStringTarget(unittest.TestCase):
 
     def test_to_string_unknown_unit_raises(self):
         """Unknown string target raises UnknownUnitError."""
-        from ucon.units import UnknownUnitError
         with self.assertRaises(UnknownUnitError):
             units.meter(1).to("not_a_unit")
 

--- a/tests/ucon/test_serialization.py
+++ b/tests/ucon/test_serialization.py
@@ -40,6 +40,63 @@ from ucon.serialization import (
     to_toml,
     from_toml,
 )
+from ucon import Dimension
+from ucon import units
+from ucon.aspects.types import AspectRule
+from ucon.basis import Basis, BasisComponent
+from ucon.basis import Basis, BasisGraph, BasisTransform
+from ucon.basis import Basis, BasisTransform
+from ucon.basis import Basis, Vector
+from ucon.basis import Vector
+from ucon.basis.builtin import SI
+from ucon.constants import Constant
+from ucon.contexts import ConversionContext, ContextEdge
+from ucon.contexts import ConversionContext, ContextEdge, using_context
+from ucon.contexts import _add_context_edge
+from ucon.conversion import ConversionGraph
+from ucon.core import RebasedUnit
+from ucon.core import RebasedUnit, Unit
+from ucon.core import Scale
+from ucon.core import Unit
+from ucon.core import UnitFactor, Scale, UnitProduct
+from ucon.dimension import Dimension
+from ucon.dimension import ENERGY
+from ucon.dimension import ENERGY, FORCE, LENGTH
+from ucon.dimension import ENERGY, NONE
+from ucon.dimension import _STANDARD_ATTRS
+from ucon.formulas import FormulaRegistry
+from ucon.formulas import FormulaRegistry, KindFormula
+from ucon.formulas import KindFormula
+from ucon.kinds import JoinPolicy, Kind
+from ucon.kinds import JoinPolicy, Kind, KindLattice
+from ucon.kinds import JoinPolicy, KindLattice
+from ucon.kinds import JoinRefused
+from ucon.kinds import Kind
+from ucon.kinds import Kind, KindLattice
+from ucon.kinds import KindLattice
+from ucon.maps import Map
+from ucon.packages import ConstantDef
+from ucon.packages import ConstantDef, PackageLoadError
+from ucon.packages import _build_map
+from ucon.packages import _build_map, PackageLoadError
+from ucon.packages import _find_map_class
+from ucon.packages import _resolve_value
+from ucon.packages import load_package
+from ucon.resolver import parse_unit
+from ucon.serialization import _collect_kinds
+from ucon.serialization import _collect_transforms
+from ucon.serialization import _collect_units
+from ucon.serialization import _dimension_to_expression
+from ucon.serialization import _serialize_formula
+from ucon.serialization import _serialize_kind
+from ucon.system import active_formulas
+from ucon.system import active_kinds
+from ucon.system import active_system, use
+from ucon.basis.transforms import (
+    BasisComponent,
+    ConstantBinding,
+    ConstantBoundBasisTransform,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +287,6 @@ class TestRoundTrip:
         graph.to_toml(path)
         restored = ConversionGraph.from_toml(path)
 
-        from ucon import units
 
         # Test meter → foot conversion
         src = units.meter
@@ -247,7 +303,6 @@ class TestRoundTrip:
         graph.to_toml(path)
         restored = ConversionGraph.from_toml(path)
 
-        from ucon import units
 
         with using_conversion_graph(restored):
             # celsius → kelvin
@@ -265,7 +320,6 @@ class TestRoundTrip:
         graph.to_toml(path)
         restored = ConversionGraph.from_toml(path)
 
-        from ucon import units
 
         with using_conversion_graph(restored):
             # watt → dBm: 10*log10(P/1mW)
@@ -281,7 +335,6 @@ class TestRoundTrip:
         graph.to_toml(path)
         restored = ConversionGraph.from_toml(path)
 
-        from ucon import units
 
         with using_conversion_graph(restored):
             # dyne → newton (CGS → SI)
@@ -310,7 +363,6 @@ class TestRoundTrip:
         the definitional decomposition.  This test asserts each unit's
         ``(prefactor, factors)`` pair is preserved bit-for-bit.
         """
-        from ucon.core import RebasedUnit
 
         def iter_units(g):
             seen: set[int] = set()
@@ -395,7 +447,6 @@ class TestRoundTrip:
 class TestPackageRoundTrip:
     def test_loaded_packages_preserved(self, tmp_path):
         """loaded_packages survives round-trip."""
-        from ucon.packages import load_package
 
         graph = get_default_graph()
         pkg = load_package("examples/units/aerospace.ucon.toml")
@@ -409,7 +460,6 @@ class TestPackageRoundTrip:
 
     def test_constant_unit_roundtrip(self, tmp_path):
         """Constant unit expressions (e.g., 'm/s') survive round-trip."""
-        from ucon.packages import load_package
 
         graph = get_default_graph()
         pkg = load_package("examples/units/aerospace.ucon.toml")
@@ -434,7 +484,6 @@ class TestPackageRoundTrip:
 class TestGraphEquality:
     def test_product_edge_equality(self):
         """__eq__ detects product edge differences."""
-        from ucon import units
         g1 = get_default_graph()
         g2 = g1.copy()
         assert g1 == g2
@@ -449,8 +498,6 @@ class TestGraphEquality:
 
     def test_equality_is_symmetric(self):
         """A == B implies B == A; extra edges in B detected from A's side."""
-        from ucon import units
-        from ucon.dimension import Dimension
 
         g1 = ConversionGraph()
         g2 = ConversionGraph()
@@ -476,8 +523,6 @@ class TestGraphEquality:
 
     def test_different_package_constants(self):
         """Graphs with different _package_constants are not equal."""
-        from ucon.constants import Constant
-        from ucon import units
 
         g1 = get_default_graph()
         g2 = g1.copy()
@@ -500,7 +545,6 @@ class TestGraphEquality:
 
     def test_cross_basis_edge_map_difference_detected(self):
         """Tampered cross-basis edge map causes inequality."""
-        from ucon.core import RebasedUnit
 
         g1 = get_default_graph()
         g2 = g1.copy()
@@ -524,8 +568,6 @@ class TestGraphEquality:
 
     def test_constant_name_difference_detected(self):
         """Constants with different name/source fields cause inequality."""
-        from ucon.constants import Constant
-        from ucon.packages import load_package
 
         g1 = get_default_graph()
         pkg = load_package("examples/units/aerospace.ucon.toml")
@@ -550,7 +592,6 @@ class TestGraphEquality:
 class TestBuildMapComposed:
     def test_composed_map_from_spec(self):
         """_build_map handles composed type."""
-        from ucon.packages import _build_map
 
         spec = {
             "type": "composed",
@@ -566,7 +607,6 @@ class TestBuildMapComposed:
 
     def test_composed_map_missing_keys(self):
         """_build_map raises on composed without outer/inner."""
-        from ucon.packages import _build_map, PackageLoadError
 
         with pytest.raises(PackageLoadError):
             _build_map({"type": "composed", "outer": {"type": "linear", "a": 1.0}})
@@ -806,8 +846,6 @@ class TestScaledProductEdges:
 
     def test_scaled_product_edge_roundtrip(self, tmp_path):
         """kilo*watt * hour → joule product edge survives export/import."""
-        from ucon import units
-        from ucon.core import UnitFactor, Scale, UnitProduct
 
         graph = get_default_graph()
         kwh = UnitProduct({
@@ -824,8 +862,6 @@ class TestScaledProductEdges:
 
     def test_product_expression_with_prefix(self):
         """parse_unit resolves 'kwatt*hour' with Scale.kilo."""
-        from ucon.core import Scale
-        from ucon.resolver import parse_unit
 
         graph = get_default_graph()
         with using_conversion_graph(graph):
@@ -849,8 +885,6 @@ class TestContextSerialization:
 
     def test_context_roundtrip(self, tmp_path):
         """Register spectroscopy context on graph, export, import, verify equality."""
-        from ucon.contexts import ConversionContext, ContextEdge
-        from ucon import units
 
         graph = get_default_graph()
 
@@ -881,8 +915,6 @@ class TestContextSerialization:
 
     def test_context_edges_in_toml(self, tmp_path):
         """Export graph with context, inspect TOML structure."""
-        from ucon.contexts import ConversionContext, ContextEdge
-        from ucon import units
 
         graph = get_default_graph()
         ctx = ConversionContext(
@@ -916,8 +948,6 @@ class TestContextSerialization:
 
     def test_context_activation_after_roundtrip(self, tmp_path):
         """Import graph with context, activate it, verify conversion works."""
-        from ucon.contexts import ConversionContext, ContextEdge, using_context
-        from ucon import units
 
         c = 299792458.0
 
@@ -944,7 +974,6 @@ class TestContextSerialization:
         with using_conversion_graph(restored):
             # Build a temporary graph with context edges applied
             extended = restored.copy()
-            from ucon.contexts import _add_context_edge
             for edge in restored_ctx.edges:
                 _add_context_edge(extended, edge)
             with using_conversion_graph(extended):
@@ -976,7 +1005,6 @@ class TestSerializeMapEdgeCases:
 
     def test_unknown_map_type_raises(self):
         """Serializing an unknown Map subclass raises TypeError (line 106)."""
-        from ucon.maps import Map
 
         class CustomMap(Map):
             def __call__(self, x): return x
@@ -992,7 +1020,6 @@ class TestSerializeMapEdgeCases:
 
     def test_unit_sort_key(self):
         """_unit_sort_key returns the unit name (line 115)."""
-        from ucon import units
         assert _unit_sort_key(units.meter) == "meter"
 
 
@@ -1003,7 +1030,6 @@ class TestSerializeMapEdgeCases:
 class TestSerializeBasisSymbol:
     def test_component_with_distinct_symbol(self):
         """BasisComponent with symbol != name emits symbol key (line 231)."""
-        from ucon.basis import Basis, BasisComponent
         b = Basis("test", [BasisComponent("length", "L")])
         d = _serialize_basis(b)
         assert d["components"][0]["name"] == "length"
@@ -1011,7 +1037,6 @@ class TestSerializeBasisSymbol:
 
     def test_component_symbol_same_as_name_omits(self):
         """BasisComponent with symbol == name omits symbol key."""
-        from ucon.basis import Basis, BasisComponent
         b = Basis("test", [BasisComponent("length", "length")])
         d = _serialize_basis(b)
         assert "symbol" not in d["components"][0]
@@ -1024,8 +1049,6 @@ class TestSerializeBasisSymbol:
 class TestSerializeConstant:
     def test_constant_with_uncertainty(self):
         """Constant with uncertainty includes uncertainty key (line 315)."""
-        from ucon.constants import Constant
-        from ucon import units
 
         c = Constant(
             symbol="G", name="gravitational constant",
@@ -1038,8 +1061,6 @@ class TestSerializeConstant:
 
     def test_constant_with_nondefault_source(self):
         """Constant with non-CODATA source includes source key (line 316→318)."""
-        from ucon.constants import Constant
-        from ucon import units
 
         c = Constant(
             symbol="k", name="custom constant",
@@ -1052,8 +1073,6 @@ class TestSerializeConstant:
 
     def test_constant_default_source_omitted(self):
         """Constant with default source 'CODATA 2022' omits source key."""
-        from ucon.constants import Constant
-        from ucon import units
 
         c = Constant(
             symbol="c", name="speed of light",
@@ -1092,8 +1111,6 @@ class TestTomlExportImportError:
 class TestCollectTransformsFromBasisGraph:
     def test_basis_graph_transforms_included(self):
         """Transforms from basis_graph._edges are included (line 434)."""
-        from ucon.serialization import _collect_transforms
-        from ucon.basis import Basis, BasisGraph, BasisTransform
         from fractions import Fraction
 
         a = Basis("A", ["x"])
@@ -1118,10 +1135,6 @@ class TestCollectTransformsFromBasisGraph:
 class TestCollectUnitsSkipsRebased:
     def test_rebased_unit_excluded(self):
         """RebasedUnit entries in _name_registry_cs are skipped (line 444)."""
-        from ucon.serialization import _collect_units
-        from ucon.core import RebasedUnit, Unit
-        from ucon.dimension import Dimension
-        from ucon.basis import Basis, BasisTransform
         from fractions import Fraction
 
         a = Basis("A", ["x"])
@@ -1150,8 +1163,6 @@ class TestCollectUnitsSkipsRebased:
 class TestProductKey:
     def test_product_key_basic(self):
         """_product_key produces a sorted tuple of factor metadata (line 488)."""
-        from ucon import units
-        from ucon.core import UnitFactor, Scale, UnitProduct
 
         prod = UnitProduct({
             UnitFactor(units.meter, Scale.one): 1,
@@ -1169,9 +1180,6 @@ class TestProductKey:
 class TestExtractCrossBasisBranches:
     def test_dim_not_in_unit_edges_skipped(self):
         """Rebased unit whose dimension is not in _unit_edges is skipped (line 193)."""
-        from ucon.core import RebasedUnit, Unit
-        from ucon.dimension import Dimension
-        from ucon.basis import Basis, BasisTransform
         from fractions import Fraction
 
         a = Basis("A", ["x"])
@@ -1190,9 +1198,6 @@ class TestExtractCrossBasisBranches:
 
     def test_rebased_not_in_dim_edges_skipped(self):
         """Rebased unit not present as a source in _unit_edges[dim] is skipped (line 195)."""
-        from ucon.core import RebasedUnit, Unit
-        from ucon.dimension import Dimension
-        from ucon.basis import Basis, BasisTransform
         from fractions import Fraction
 
         a = Basis("A", ["x"])
@@ -1429,7 +1434,6 @@ class TestStrictModeBranches:
 class TestResolveUnitFallbacks:
     def test_resolve_from_graph_registry(self):
         """Unit resolved from graph.resolve_unit() when not in unit_map (line 833)."""
-        from ucon import units
 
         graph = get_default_graph()
         # unit_map intentionally missing 'meter'
@@ -1439,7 +1443,6 @@ class TestResolveUnitFallbacks:
 
     def test_resolve_case_insensitive(self):
         """Case-insensitive fallback in _name_registry (line 836)."""
-        from ucon import units
 
         graph = ConversionGraph()
         u = units.meter
@@ -1472,7 +1475,6 @@ class TestResolveContextUnit:
 
     def test_context_unit_fallback_to_local(self):
         """_resolve_context_unit falls back to _resolve_unit on exception (lines 852–855)."""
-        from ucon import units
 
         graph = ConversionGraph()
         graph.register_unit(units.meter)
@@ -1513,7 +1515,6 @@ class TestResolveProductExpression:
 
     def test_fallback_to_local_resolution(self):
         """Resolver failure falls back to _resolve_unit via unit_map."""
-        from ucon import units
 
         graph = ConversionGraph()
         graph.register_unit(units.meter)
@@ -1545,8 +1546,6 @@ class TestResolveProductExpression:
 class TestSerializeDimensionFractional:
     def test_fractional_vector_component(self):
         """Dimension with fractional vector component serializes as string (line 244)."""
-        from ucon.basis import Basis, Vector
-        from ucon.dimension import Dimension
         from fractions import Fraction
 
         b = Basis("test", ["a", "b"])
@@ -1569,8 +1568,6 @@ class TestSerializeDimensionSymbol:
 
     def test_serialize_dimension_with_symbol(self):
         """Dimension with symbol emits symbol key."""
-        from ucon.basis import Basis, Vector
-        from ucon.dimension import Dimension
         from fractions import Fraction
 
         b = Basis("test", ["a"])
@@ -1581,8 +1578,6 @@ class TestSerializeDimensionSymbol:
 
     def test_serialize_dimension_without_symbol_omits_key(self):
         """Dimension without symbol omits the key."""
-        from ucon.basis import Basis, Vector
-        from ucon.dimension import Dimension
         from fractions import Fraction
 
         b = Basis("test", ["a"])
@@ -1593,7 +1588,6 @@ class TestSerializeDimensionSymbol:
 
     def test_symbol_round_trip_via_from_toml(self, tmp_path):
         """A non-standard dimension with a symbol survives TOML round-trip."""
-        from ucon.conversion import ConversionGraph
 
         toml_content = '''
 [package]
@@ -1639,7 +1633,6 @@ class TestDimensionCatalogParity:
         """Every standard dimension lives in the TOML, with matching vector + symbol."""
         from pathlib import Path
 
-        from ucon.dimension import _STANDARD_ATTRS
 
         toml_path = (
             Path(__file__).resolve().parent.parent.parent
@@ -1688,12 +1681,6 @@ class TestDimensionCatalogParity:
 class TestSerializeTransformBindings:
     def test_binding_fractional_target_expression(self):
         """Fractional binding target_expression serializes as string (line 287)."""
-        from ucon.basis import Basis, Vector
-        from ucon.basis.transforms import (
-            ConstantBoundBasisTransform,
-            ConstantBinding,
-            BasisComponent,
-        )
         from fractions import Fraction
 
         a = Basis("A", [BasisComponent("x", "X")])
@@ -1766,8 +1753,6 @@ class TestExportEmptySections:
 class TestContextDescriptionBranch:
     def test_context_without_description(self, tmp_path):
         """Context with empty description omits key in export (line 465→467)."""
-        from ucon.contexts import ConversionContext, ContextEdge
-        from ucon import units
 
         graph = get_default_graph()
         ctx = ConversionContext(
@@ -1800,7 +1785,6 @@ class TestContextDescriptionBranch:
 class TestRemainingCoverage:
     def test_resolve_unit_case_insensitive_fallback(self):
         """Case-different name resolved via _name_registry (line 836)."""
-        from ucon import units
 
         graph = ConversionGraph()
         graph.register_unit(units.meter)
@@ -1848,8 +1832,6 @@ class TestRemainingCoverage:
 
     def test_resolve_product_expression_local_fallback(self):
         """Product expression falls back to local resolution."""
-        from ucon.core import Unit
-        from ucon.dimension import Dimension
 
         # Create a minimal graph and put the unit ONLY in unit_map, not
         # registered in the graph, so parse_unit will fail but
@@ -1864,9 +1846,6 @@ class TestRemainingCoverage:
 
     def test_extract_cross_basis_dst_is_rebased_skipped(self):
         """RebasedUnit dst in cross-basis extraction is skipped (line 198)."""
-        from ucon.core import RebasedUnit, Unit
-        from ucon.dimension import Dimension
-        from ucon.basis import Basis, BasisTransform
         from fractions import Fraction
 
         a = Basis("A", ["x"])
@@ -1966,7 +1945,6 @@ class TestProductExpressionGrammar:
 
     def test_division_basic(self):
         """'meter/second' → meter^1, second^-1."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter/second")
@@ -1976,7 +1954,6 @@ class TestProductExpressionGrammar:
 
     def test_division_compound_num(self):
         """'kg*meter/second^2' → kg^1, meter^1, second^-2."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("kg*meter/second^2")
@@ -1987,7 +1964,6 @@ class TestProductExpressionGrammar:
 
     def test_division_then_multiply(self):
         """'meter/second*kilogram' → m^1, s^-1, kg^1 (left-to-right: * is multiply)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter/second*kilogram")
@@ -1998,7 +1974,6 @@ class TestProductExpressionGrammar:
 
     def test_compound_denominator_via_slashes(self):
         """'meter/second/kilogram' → meter^1, second^-1, kg^-1."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter/second/kilogram")
@@ -2009,7 +1984,6 @@ class TestProductExpressionGrammar:
 
     def test_triple_slash_dosage(self):
         """'gram/kilogram/day/each' → g^1, kg^-1, day^-1, ea^-1."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("gram/kilogram/day/each")
@@ -2021,7 +1995,6 @@ class TestProductExpressionGrammar:
 
     def test_backward_compat_star(self):
         """'meter*second^-1' still works."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter*second^-1")
@@ -2031,7 +2004,6 @@ class TestProductExpressionGrammar:
 
     def test_whitespace_tolerance(self):
         """'meter / second' with whitespace works."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter / second")
@@ -2041,8 +2013,6 @@ class TestProductExpressionGrammar:
 
     def test_division_with_prefix(self):
         """'kwatt/hour' → kilo-watt^1, hour^-1."""
-        from ucon.resolver import parse_unit
-        from ucon.core import Scale
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("kwatt/hour")
@@ -2060,8 +2030,6 @@ class TestProductExpressionGrammar:
 
     def test_emitter_slash_notation(self):
         """Product key with meter^1, second^-1 emits 'meter/second'."""
-        from ucon import units
-        from ucon.core import UnitFactor, Scale, UnitProduct
 
         prod = UnitProduct({
             UnitFactor(units.meter, Scale.one): 1,
@@ -2074,8 +2042,6 @@ class TestProductExpressionGrammar:
 
     def test_emitter_all_negative(self):
         """Product key with second^-1 only emits 'second^-1' (no '1/second')."""
-        from ucon import units
-        from ucon.core import UnitFactor, Scale, UnitProduct
 
         prod = UnitProduct({
             UnitFactor(units.second, Scale.one): -1,
@@ -2089,7 +2055,6 @@ class TestProductExpressionGrammar:
 
     def test_left_to_right_star_after_slash(self):
         """'meter^3/kilogram*second^2' → m^3, kg^-1, s^2 (left-to-right)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter^3/kilogram*second^2")
@@ -2100,7 +2065,6 @@ class TestProductExpressionGrammar:
 
     def test_left_to_right_multiple_star_after_slash(self):
         """'joule/mole*kelvin*second' → J^1, mol^-1, K^1, s^1 (left-to-right)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("joule/mole*kelvin*second")
@@ -2112,7 +2076,6 @@ class TestProductExpressionGrammar:
 
     def test_left_to_right_star_after_slash_with_exponents(self):
         """'watt/meter^2*kelvin^4' → W^1, m^-2, K^4 (left-to-right)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("watt/meter^2*kelvin^4")
@@ -2123,7 +2086,6 @@ class TestProductExpressionGrammar:
 
     def test_double_slash_all_denominator(self):
         """'meter/second/kilogram' → m^1, s^-1, kg^-1."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter/second/kilogram")
@@ -2134,7 +2096,6 @@ class TestProductExpressionGrammar:
 
     def test_slash_with_explicit_negative_exponent(self):
         """'meter/second^-1' → m^1, s^1 (negative exponent in denominator flips)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("meter/second^-1")
@@ -2144,7 +2105,6 @@ class TestProductExpressionGrammar:
 
     def test_float_exponents(self):
         """'joule/meter^2.0' → joule^1, meter^-2 (float exponents from emitter)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("joule/meter^2.0")
@@ -2156,7 +2116,6 @@ class TestProductExpressionGrammar:
 
     def test_parens_for_multi_denom(self):
         """'m³/(kg·s²)' → m^3, kg^-1, s^-2 (G constant with explicit parens)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("m³/(kg·s²)")
@@ -2167,7 +2126,6 @@ class TestProductExpressionGrammar:
 
     def test_parens_stefan_boltzmann(self):
         """'W/(m²·K⁴)' → W^1, m^-2, K^-4."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("W/(m²·K⁴)")
@@ -2178,7 +2136,6 @@ class TestProductExpressionGrammar:
 
     def test_parens_molar_gas(self):
         """'J/(mol·K)' → J^1, mol^-1, K^-1."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("J/(mol·K)")
@@ -2189,7 +2146,6 @@ class TestProductExpressionGrammar:
 
     def test_without_parens_is_left_to_right(self):
         """'m³/kg·s²' without parens is left-to-right: (m³/kg)·s² = m³·s²/kg."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("m³/kg·s²")
@@ -2200,7 +2156,6 @@ class TestProductExpressionGrammar:
 
     def test_unicode_no_slash_all_positive(self):
         """'kg·m·s' → all positive (no slash means no denominator)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("kg·m·s")
@@ -2211,7 +2166,6 @@ class TestProductExpressionGrammar:
 
     def test_parens_override_left_to_right(self):
         """'kg/(m·s²)·A' → kg^1, m^-1, s^-2, A^1 (parens group then multiply A)."""
-        from ucon.resolver import parse_unit
         graph = get_default_graph()
         with using_conversion_graph(graph):
             result = parse_unit("kg/(m·s²)·A")
@@ -2223,9 +2177,6 @@ class TestProductExpressionGrammar:
 
     def test_shorthand_roundtrip_multi_denom(self):
         """UnitProduct.shorthand (Unicode) round-trips through parse_unit."""
-        from ucon import units
-        from ucon.core import UnitFactor, Scale, UnitProduct
-        from ucon.resolver import parse_unit
 
         prod = UnitProduct({
             UnitFactor(units.meter, Scale.one): 3,
@@ -2245,8 +2196,6 @@ class TestProductExpressionGrammar:
 
     def test_roundtrip_division(self, tmp_path):
         """Product edges with '/' notation survive export + reimport."""
-        from ucon import units
-        from ucon.core import UnitFactor, Scale, UnitProduct
 
         graph = get_default_graph()
         m_per_s = UnitProduct({
@@ -2339,7 +2288,6 @@ class TestMapToDict:
 
     def test_no_map_type_raises(self):
         """Custom Map without _map_type raises TypeError."""
-        from ucon.maps import Map
 
         class BareMap(Map):
             def __call__(self, x): return x
@@ -2372,7 +2320,6 @@ class TestImplicitMapDiscovery:
 
     def test_builtin_types_discovered(self):
         """All built-in map types are discoverable via _find_map_class."""
-        from ucon.packages import _find_map_class
 
         assert _find_map_class("linear") is LinearMap
         assert _find_map_class("affine") is AffineMap
@@ -2381,8 +2328,6 @@ class TestImplicitMapDiscovery:
 
     def test_custom_subclass_discovered(self):
         """A custom Map subclass with _map_type is discovered automatically."""
-        from ucon.packages import _find_map_class
-        from ucon.maps import Map
         from dataclasses import dataclass
 
         @dataclass(frozen=True)
@@ -2401,21 +2346,18 @@ class TestImplicitMapDiscovery:
 
     def test_unknown_type_raises(self):
         """_build_map raises PackageLoadError for unknown type names."""
-        from ucon.packages import _build_map, PackageLoadError
 
         with pytest.raises(PackageLoadError, match="Unknown map type"):
             _build_map({"type": "totally_unknown"})
 
     def test_missing_type_key_raises(self):
         """_build_map raises PackageLoadError when 'type' key is absent."""
-        from ucon.packages import _build_map, PackageLoadError
 
         with pytest.raises(PackageLoadError, match="requires a 'type' key"):
             _build_map({"a": 1.0})
 
     def test_recursive_deserialization(self):
         """Nested map specs are recursively deserialized."""
-        from ucon.packages import _build_map
 
         spec = {
             "type": "composed",
@@ -2432,7 +2374,6 @@ class TestImplicitMapDiscovery:
 
     def test_deeply_nested_recursion(self):
         """Three-level nesting works: composed of composed of linear."""
-        from ucon.packages import _build_map
 
         spec = {
             "type": "composed",
@@ -2451,9 +2392,6 @@ class TestImplicitMapDiscovery:
 
     def test_roundtrip_custom_map(self, tmp_path):
         """Custom Map subclass survives export/import via implicit discovery."""
-        from ucon.maps import Map
-        from ucon import units
-        from ucon.core import UnitFactor, Scale, UnitProduct
         from dataclasses import dataclass
 
         @dataclass(frozen=True)
@@ -2483,7 +2421,6 @@ class TestImplicitMapDiscovery:
 
     def test_list_resolution(self):
         """List values containing map specs are recursively resolved."""
-        from ucon.packages import _resolve_value
 
         result = _resolve_value([
             {"type": "linear", "a": 2.0},
@@ -2494,14 +2431,12 @@ class TestImplicitMapDiscovery:
 
     def test_plain_dict_passthrough(self):
         """A dict without a 'type' key passes through unchanged."""
-        from ucon.packages import _resolve_value
 
         d = {"a": 1.0, "b": 2.0}
         assert _resolve_value(d) is d
 
     def test_scalar_passthrough(self):
         """Scalars pass through _resolve_value unchanged."""
-        from ucon.packages import _resolve_value
 
         assert _resolve_value(3.14) == 3.14
         assert _resolve_value("hello") == "hello"
@@ -2516,10 +2451,6 @@ class TestConstantKindSerialization:
 
     def test_serialize_constant_with_kind(self):
         """_serialize_constant includes kind when set."""
-        from ucon.constants import Constant
-        from ucon import units
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
 
         ke = Kind("kinetic_energy", dimension=ENERGY)
         c = Constant(
@@ -2532,8 +2463,6 @@ class TestConstantKindSerialization:
 
     def test_serialize_constant_without_kind(self):
         """_serialize_constant omits kind when None."""
-        from ucon.constants import Constant
-        from ucon import units
 
         c = Constant(
             symbol="c", name="speed of light",
@@ -2573,11 +2502,6 @@ class TestConstantKindSerialization:
 
     def test_constant_kind_roundtrip(self, tmp_path):
         """Kind survives export → reimport round-trip on a Constant."""
-        from ucon.constants import Constant
-        from ucon import units
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind, KindLattice
-        from ucon.system import active_system, use
 
         ke = Kind("kinetic_energy", dimension=ENERGY)
         lattice = KindLattice([ke])
@@ -2612,10 +2536,6 @@ class TestConstantKindSerialization:
 
     def test_constant_as_number_preserves_kind(self):
         """Constant.as_number() passes kind through."""
-        from ucon.constants import Constant
-        from ucon import units
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
 
         ke = Kind("kinetic_energy", dimension=ENERGY)
         c = Constant(
@@ -2632,10 +2552,6 @@ class TestConstantDefKind:
 
     def test_constant_def_with_kind(self):
         """ConstantDef with kind materializes with resolved Kind."""
-        from ucon.packages import ConstantDef
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind, KindLattice
-        from ucon.system import active_system, use
 
         ke = Kind("kinetic_energy", dimension=ENERGY)
         lattice = KindLattice([ke])
@@ -2655,7 +2571,6 @@ class TestConstantDefKind:
 
     def test_constant_def_without_kind(self):
         """ConstantDef without kind materializes with kind=None."""
-        from ucon.packages import ConstantDef
 
         cdef = ConstantDef(
             symbol="c", name="speed of light",
@@ -2668,7 +2583,6 @@ class TestConstantDefKind:
 
     def test_constant_def_unknown_kind_raises(self):
         """ConstantDef with unknown kind raises PackageLoadError."""
-        from ucon.packages import ConstantDef, PackageLoadError
 
         cdef = ConstantDef(
             symbol="x", name="test",
@@ -2690,9 +2604,6 @@ class TestKindsSerialization:
 
     def test_serialize_kind_basic(self):
         """Root kind with default join_policy produces compact dict."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
-        from ucon.serialization import _serialize_kind
 
         k = Kind("energy", dimension=ENERGY)
         d = _serialize_kind(k)
@@ -2703,9 +2614,6 @@ class TestKindsSerialization:
 
     def test_serialize_kind_with_parent(self):
         """Kind with parent emits parent key."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
-        from ucon.serialization import _serialize_kind
 
         root = Kind("energy", dimension=ENERGY)
         child = Kind("kinetic_energy", dimension=ENERGY, parent=root)
@@ -2714,9 +2622,6 @@ class TestKindsSerialization:
 
     def test_serialize_kind_with_refuse_policy(self):
         """Non-default join_policy is emitted."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import JoinPolicy, Kind
-        from ucon.serialization import _serialize_kind
 
         k = Kind("energy", dimension=ENERGY, join_policy=JoinPolicy.REFUSE)
         d = _serialize_kind(k)
@@ -2724,9 +2629,6 @@ class TestKindsSerialization:
 
     def test_serialize_kind_default_policy_omitted(self):
         """Default LCA policy is not emitted."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
-        from ucon.serialization import _serialize_kind
 
         k = Kind("energy", dimension=ENERGY)
         d = _serialize_kind(k)
@@ -2734,9 +2636,6 @@ class TestKindsSerialization:
 
     def test_serialize_kind_with_aliases(self):
         """Kind with aliases emits aliases list."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
-        from ucon.serialization import _serialize_kind
 
         k = Kind("kinetic_energy", dimension=ENERGY, aliases=("KE", "T"))
         d = _serialize_kind(k)
@@ -2744,9 +2643,6 @@ class TestKindsSerialization:
 
     def test_serialize_kind_empty_aliases_omitted(self):
         """Kind with no aliases does not emit aliases key."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind
-        from ucon.serialization import _serialize_kind
 
         k = Kind("energy", dimension=ENERGY)
         d = _serialize_kind(k)
@@ -2754,8 +2650,6 @@ class TestKindsSerialization:
 
     def test_kinds_section_in_toml(self, tmp_path):
         """to_toml with explicit KindLattice emits [[kinds]] section."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind, KindLattice
 
         root = Kind("energy", dimension=ENERGY)
         child = Kind("kinetic_energy", dimension=ENERGY, parent=root)
@@ -2772,7 +2666,6 @@ class TestKindsSerialization:
 
     def test_no_kinds_section_when_empty(self, tmp_path):
         """to_toml with empty KindLattice omits [[kinds]] section."""
-        from ucon.kinds import KindLattice
 
         graph = get_default_graph()
         path = tmp_path / "no_kinds.ucon.toml"
@@ -2784,8 +2677,6 @@ class TestKindsSerialization:
 
     def test_kinds_roundtrip(self, tmp_path):
         """Kind lattice survives to_toml → from_toml round-trip."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind, KindLattice
 
         root = Kind("energy", dimension=ENERGY)
         child = Kind("kinetic_energy", dimension=ENERGY, parent=root)
@@ -2806,8 +2697,6 @@ class TestKindsSerialization:
 
     def test_kinds_with_aliases_roundtrip(self, tmp_path):
         """Kind aliases survive round-trip."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind, KindLattice
 
         k = Kind("kinetic_energy", dimension=ENERGY, aliases=("KE",))
         lattice = KindLattice([k])
@@ -2823,8 +2712,6 @@ class TestKindsSerialization:
 
     def test_kinds_with_refuse_policy_roundtrip(self, tmp_path):
         """Non-default join_policy survives round-trip."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import JoinPolicy, Kind, KindLattice
 
         k = Kind("energy", dimension=ENERGY, join_policy=JoinPolicy.REFUSE)
         lattice = KindLattice([k])
@@ -2850,16 +2737,12 @@ class TestKindsSerialization:
 
     def test_constant_kind_resolved_from_local_lattice(self, tmp_path):
         """Constant kind field resolves from locally-parsed [[kinds]]."""
-        from ucon.dimension import ENERGY
-        from ucon.kinds import Kind, KindLattice
 
         root = Kind("energy", dimension=ENERGY)
         child = Kind("kinetic_energy", dimension=ENERGY, parent=root)
         lattice = KindLattice([root, child])
 
         # Build a graph with a kinded constant
-        from ucon.constants import Constant
-        from ucon import units
 
         graph = get_default_graph().copy()
         kinded_const = Constant(
@@ -2888,8 +2771,6 @@ class TestKindsSerialization:
 
     def test_builtin_kinds_roundtrip(self, tmp_path):
         """All 25 built-in kinds survive to_toml → from_toml round-trip."""
-        from ucon.kinds import JoinPolicy, KindLattice
-        from ucon.system import active_kinds
 
         original = active_kinds()
         assert len(original) == 26, "Expected 26 built-in kinds"
@@ -2930,7 +2811,6 @@ class TestKindsSerialization:
 
     def test_builtin_kinds_join_semantics_survive_roundtrip(self, tmp_path):
         """REFUSE/LCA join semantics are preserved through round-trip."""
-        from ucon.kinds import JoinRefused
 
         graph = get_default_graph()
         path = tmp_path / "join_semantics_rt.ucon.toml"
@@ -2955,17 +2835,11 @@ class TestKindsSerialization:
 
     def test_dimension_to_expression_named(self):
         """_dimension_to_expression returns name for named dimension."""
-        from ucon.serialization import _dimension_to_expression
-        from ucon.dimension import ENERGY
         result = _dimension_to_expression(ENERGY)
         assert result == "energy"
 
     def test_dimension_to_expression_unnamed_simple(self):
         """_dimension_to_expression builds expression from unnamed vector."""
-        from ucon.serialization import _dimension_to_expression
-        from ucon import Dimension
-        from ucon.basis import Vector
-        from ucon.basis.builtin import SI
         # L/T — anonymous dimension (no name attribute)
         v = Vector(SI, (1, 0, -1, 0, 0, 0, 0, 0))
         dim = Dimension(vector=v)
@@ -2975,10 +2849,6 @@ class TestKindsSerialization:
 
     def test_dimension_to_expression_unnamed_with_exponents(self):
         """_dimension_to_expression handles exponents > 1 and < -1."""
-        from ucon.serialization import _dimension_to_expression
-        from ucon import Dimension
-        from ucon.basis import Vector
-        from ucon.basis.builtin import SI
         # L^2 / T^2 — anonymous dimension with exponents
         v = Vector(SI, (2, 0, -2, 0, 0, 0, 0, 0))
         dim = Dimension(vector=v)
@@ -2990,7 +2860,6 @@ class TestKindsSerialization:
     def test_collect_kinds_runtime_error_fallback(self):
         """_collect_kinds returns [] when active_kinds() raises RuntimeError."""
         from unittest.mock import patch
-        from ucon.serialization import _collect_kinds
         # Pass graph=None (no _kind_lattice attr) and explicit_kinds=None
         # Mock active_kinds to raise RuntimeError
         with patch('ucon.serialization.active_kinds', side_effect=RuntimeError("no context")):
@@ -3003,10 +2872,6 @@ class TestFormulasSerialization:
 
     def test_serialize_formula_basic(self):
         """_serialize_formula produces expected keys."""
-        from ucon.dimension import ENERGY, FORCE, LENGTH
-        from ucon.kinds import Kind
-        from ucon.formulas import KindFormula
-        from ucon.serialization import _serialize_formula
 
         force_kind = Kind("force", dimension=FORCE)
         distance_kind = Kind("distance", dimension=LENGTH)
@@ -3031,11 +2896,6 @@ class TestFormulasSerialization:
 
     def test_serialize_formula_with_aspect_rules(self):
         """_serialize_formula emits aspect_rules for non-CARRY rules."""
-        from ucon.dimension import ENERGY, NONE
-        from ucon.kinds import Kind
-        from ucon.formulas import KindFormula
-        from ucon.aspects.types import AspectRule
-        from ucon.serialization import _serialize_formula
 
         absorbed = Kind("absorbed_dose", dimension=ENERGY)
         weight_factor = Kind("weighting_factor", dimension=NONE)
@@ -3055,9 +2915,6 @@ class TestFormulasSerialization:
 
     def test_formulas_roundtrip(self, tmp_path):
         """Formulas survive to_toml → from_toml round-trip."""
-        from ucon.dimension import ENERGY, FORCE, LENGTH
-        from ucon.kinds import Kind, KindLattice
-        from ucon.formulas import FormulaRegistry, KindFormula
 
         force_kind = Kind("force", dimension=FORCE)
         distance_kind = Kind("distance", dimension=LENGTH)
@@ -3088,10 +2945,6 @@ class TestFormulasSerialization:
 
     def test_formulas_with_aspect_rules_roundtrip(self, tmp_path):
         """Aspect rules survive round-trip."""
-        from ucon.dimension import ENERGY, NONE
-        from ucon.kinds import Kind, KindLattice
-        from ucon.formulas import FormulaRegistry, KindFormula
-        from ucon.aspects.types import AspectRule
 
         absorbed = Kind("absorbed_dose", dimension=ENERGY)
         wf = Kind("weight_factor", dimension=NONE)
@@ -3119,7 +2972,6 @@ class TestFormulasSerialization:
 
     def test_no_formulas_section_when_empty(self, tmp_path):
         """TOML without formulas omits the [[formulas]] section."""
-        from ucon.formulas import FormulaRegistry
 
         graph = get_default_graph()
         path = tmp_path / "no_formulas.ucon.toml"
@@ -3145,7 +2997,6 @@ class TestBuiltinFormulas:
 
     def test_radiation_formula_loaded_at_boot(self):
         """radiation_weighting formula exists in the active context."""
-        from ucon.system import active_formulas
         registry = active_formulas()
         formula = registry.get("radiation_weighting")
         assert formula.name == "radiation_weighting"
@@ -3155,7 +3006,6 @@ class TestBuiltinFormulas:
 
     def test_radiation_weighting_factor_kind_exists(self):
         """radiation_weighting_factor kind is in the active lattice."""
-        from ucon.system import active_kinds
         lattice = active_kinds()
         kind = lattice.get("radiation_weighting_factor")
         assert kind.dimension.name == "none"

--- a/tests/ucon/test_uncertainty.py
+++ b/tests/ucon/test_uncertainty.py
@@ -15,6 +15,9 @@ import unittest
 from ucon import units, Scale
 from ucon.core import UnitProduct
 from ucon.quantity import Number
+from ucon.maps import AffineMap
+from ucon.maps import LinearMap
+from ucon.maps import LinearMap, AffineMap
 
 
 class TestUncertaintyConstruction(unittest.TestCase):
@@ -239,19 +242,16 @@ class TestMapDerivative(unittest.TestCase):
     """Test Map.derivative() implementations."""
 
     def test_linear_map_derivative(self):
-        from ucon.maps import LinearMap
         m = LinearMap(3.28084)
         self.assertAlmostEqual(m.derivative(0), 3.28084, places=9)
         self.assertAlmostEqual(m.derivative(100), 3.28084, places=9)
 
     def test_affine_map_derivative(self):
-        from ucon.maps import AffineMap
         m = AffineMap(5/9, -32 * 5/9)  # F to C
         self.assertAlmostEqual(m.derivative(0), 5/9, places=9)
         self.assertAlmostEqual(m.derivative(100), 5/9, places=9)
 
     def test_composed_map_derivative(self):
-        from ucon.maps import LinearMap, AffineMap
         # Compose: first scale by 2, then add 10
         inner = LinearMap(2)
         outer = AffineMap(1, 10)

--- a/tests/ucon/test_unit_system.py
+++ b/tests/ucon/test_unit_system.py
@@ -15,6 +15,8 @@ from ucon import units
 from ucon.core import DimensionNotCovered
 from ucon.system import BaseUnits
 from ucon import Dimension
+from ucon.units import imperial
+from ucon.units import si
 
 
 class TestBaseUnitsConstruction(unittest.TestCase):
@@ -159,14 +161,12 @@ class TestPredefinedSystems(unittest.TestCase):
     """Test predefined unit systems in ucon.units."""
 
     def test_si_system_exists(self):
-        from ucon.units import si
         self.assertEqual(si.name, "SI")
         self.assertTrue(si.covers(Dimension.length))
         self.assertTrue(si.covers(Dimension.mass))
         self.assertTrue(si.covers(Dimension.time))
 
     def test_imperial_system_exists(self):
-        from ucon.units import imperial
         self.assertEqual(imperial.name, "Imperial")
         self.assertTrue(imperial.covers(Dimension.length))
         self.assertTrue(imperial.covers(Dimension.mass))

--- a/tests/ucon/test_unit_system_value_type.py
+++ b/tests/ucon/test_unit_system_value_type.py
@@ -25,6 +25,37 @@ from ucon.system import (
     active_system,
     use,
 )
+from ucon import Dimension as Dim
+from ucon import Dimension, units as _units_module
+from ucon.basis.builtin import SI
+from ucon.basis.graph import BasisGraph
+from ucon.basis.ops import unify
+from ucon.basis.transforms import BasisTransform
+from ucon.basis.types import Basis
+from ucon.basis.types import Basis, BasisComponent
+from ucon.basis.types import Basis, BasisComponent, BasisMismatch
+from ucon.checking import enforce_dimensions
+from ucon.core import DimensionConstraint, Number
+from ucon.core import Number, Unit
+from ucon.core import Unit
+from ucon.core import Unit, UnitProduct
+from ucon.core import UnitProduct
+from ucon.dimension import Dimension
+from ucon.dimension import Dimension as Dim
+from ucon.graph import ConversionGraph
+from ucon.parsing.dimensions import parse_dimension
+from ucon.parsing.quantity import parse
+from ucon.resolver import parse_unit
+from ucon.system import BaseUnits as BU  # noqa: F401
+from ucon.system import UnitSystem
+from ucon.system import UnitSystem as US  # noqa: F401
+from ucon.system import active as a, use as u  # noqa: F401
+from ucon.system import use
+from ucon.units import kelvin, meter
+from ucon.units import meter
+from ucon.units import meter as real_meter
+from ucon.units import meter, second
+from ucon.units import second
 
 
 class TestAlgebraCache(unittest.TestCase):
@@ -123,15 +154,12 @@ class TestActiveAndUse(unittest.TestCase):
 
 class TestPublicSurface(unittest.TestCase):
     def test_baseunits_importable_from_ucon_system(self):
-        from ucon.system import BaseUnits as BU  # noqa: F401
         self.assertIs(BU, BaseUnits)
 
     def test_unitsystem_importable_from_ucon_system(self):
-        from ucon.system import UnitSystem as US  # noqa: F401
         self.assertIs(US, UnitSystem)
 
     def test_use_and_active_importable_from_ucon_system(self):
-        from ucon.system import active as a, use as u  # noqa: F401
         self.assertTrue(callable(a))
         self.assertTrue(callable(u))
 
@@ -162,7 +190,6 @@ class TestUnitSystemDifferentialEquality(unittest.TestCase):
         self.assertIs(s.__eq__(None), NotImplemented)
 
     def test_different_base_units_not_equal(self):
-        from ucon import Dimension, units as _units_module
         s = active_system()
         twin = self._twin(
             s,
@@ -173,7 +200,6 @@ class TestUnitSystemDifferentialEquality(unittest.TestCase):
         self.assertNotEqual(s, twin)
 
     def test_different_basis_not_equal(self):
-        from ucon.basis.types import Basis
         s = active_system()
         twin = self._twin(s, basis=Basis("Synthetic", ["x", "y"]))
         self.assertNotEqual(s, twin)
@@ -278,7 +304,6 @@ class TestBaseUnitsHashOrderStability(unittest.TestCase):
     """``BaseUnits.__hash__`` must be invariant under bases insertion order."""
 
     def test_hash_independent_of_insertion_order(self):
-        from ucon import Dimension, units as _units_module
         s1 = BaseUnits(name="X", bases={
             Dimension.length: _units_module.meter,
             Dimension.mass: _units_module.kilogram,
@@ -303,7 +328,6 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
     """
 
     def test_number_to_accepts_system_kwarg(self):
-        from ucon.units import meter
         system = active_system()
         result = meter(100).to("km", system=system)
         self.assertAlmostEqual(result.quantity, 0.1)
@@ -313,16 +337,12 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
         # takes precedence. We verify this by passing a "wrong" graph
         # via graph= and observing the conversion still succeeds via
         # system.conversion_graph.
-        from ucon.graph import ConversionGraph
-        from ucon.units import meter
         bogus_graph = ConversionGraph()  # empty, would fail conversion
         system = active_system()
         result = meter(100).to("km", graph=bogus_graph, system=system)
         self.assertAlmostEqual(result.quantity, 0.1)
 
     def test_parse_unit_accepts_system_kwarg(self):
-        from ucon.resolver import parse_unit
-        from ucon.core import Unit
         system = active_system()
         unit = parse_unit("meter", system=system)
         self.assertIsInstance(unit, Unit)
@@ -330,8 +350,6 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
     def test_parse_unit_system_override_short_circuits(self):
         # If system.units has a direct entry for the name, parse_unit
         # returns that without consulting the global registry.
-        from ucon.resolver import parse_unit
-        from ucon.units import meter as real_meter
         # Build a minimal custom system: only "widget" is in units.
         # Because parse_unit consults system.units first, "widget"
         # resolves; bare "meter" still falls through to the global
@@ -345,7 +363,6 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
         # When system.units does not have the name, parse_unit falls
         # back to the global registry so prefix decomposition still
         # works.
-        from ucon.resolver import parse_unit
         class _EmptySystem:
             units = {}
         result = parse_unit("km", system=_EmptySystem())
@@ -354,22 +371,17 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
         self.assertIsNotNone(result)
 
     def test_parse_quantity_threads_system(self):
-        from ucon.parsing.quantity import parse
         system = active_system()
         n = parse("60 mph", system=system)
         self.assertEqual(n.quantity, 60.0)
 
     def test_parse_dimension_accepts_system_kwarg(self):
-        from ucon.parsing.dimensions import parse_dimension
-        from ucon.dimension import Dimension as Dim
         system = active_system()
         result = parse_dimension("length", system=system)
         self.assertEqual(result, Dim.length)
 
     def test_parse_dimension_system_overrides_basis(self):
         # When basis= is omitted, system.basis is used as the default.
-        from ucon.parsing.dimensions import parse_dimension
-        from ucon.basis.builtin import SI
         system = active_system()
         # SI basis is the default; verify "M" parses against system.basis.
         self.assertEqual(system.basis, SI)
@@ -379,10 +391,6 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
     def test_enforce_dimensions_factory_form(self):
         # @enforce_dimensions(system=sys) returns a decorator that
         # validates and coerces against the supplied system.
-        from ucon import Dimension as Dim
-        from ucon.checking import enforce_dimensions
-        from ucon.core import DimensionConstraint, Number
-        from ucon.units import meter, second
 
         system = active_system()
 
@@ -397,10 +405,6 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
         self.assertIsNotNone(result)
 
     def test_enforce_dimensions_factory_rejects_wrong_dim(self):
-        from ucon import Dimension as Dim
-        from ucon.checking import enforce_dimensions
-        from ucon.core import DimensionConstraint, Number
-        from ucon.units import meter, second
 
         system = active_system()
 
@@ -417,10 +421,6 @@ class TestUnitSystemEntryPointKwargs(unittest.TestCase):
     def test_enforce_dimensions_bare_form_still_works(self):
         # Backward-compatibility: @enforce_dimensions (no parens) is
         # the legacy form. It must continue to function.
-        from ucon import Dimension as Dim
-        from ucon.checking import enforce_dimensions
-        from ucon.core import DimensionConstraint, Number
-        from ucon.units import meter, second
 
         @enforce_dimensions
         def speed(
@@ -445,9 +445,6 @@ class TestCompoundParserSystemRouting(unittest.TestCase):
     def test_composite_resolves_via_system_units(self):
         # A composite expression "widget/widget2" resolves entirely from
         # system.units, even though neither name is in the global registry.
-        from ucon.core import Unit, UnitProduct
-        from ucon.resolver import parse_unit
-        from ucon.units import meter, second
 
         class _CurrencyLikeSystem:
             # Stand-ins: pretend `meter`-shaped unit acts as "widget"
@@ -466,9 +463,6 @@ class TestCompoundParserSystemRouting(unittest.TestCase):
     def test_composite_mixes_system_and_global_factors(self):
         # When system.units provides one factor and the other is in the
         # global registry, both should resolve.
-        from ucon.core import UnitProduct
-        from ucon.resolver import parse_unit
-        from ucon.units import meter
 
         class _PartialSystem:
             units = {"widget": meter}
@@ -480,8 +474,6 @@ class TestCompoundParserSystemRouting(unittest.TestCase):
     def test_composite_falls_back_when_system_empty(self):
         # If system.units is empty, composite parsing falls through to
         # the global registry exactly as it does without ``system=``.
-        from ucon.core import UnitProduct
-        from ucon.resolver import parse_unit
 
         class _EmptySystem:
             units = {}
@@ -492,8 +484,6 @@ class TestCompoundParserSystemRouting(unittest.TestCase):
     def test_composite_without_system_still_works(self):
         # Backward-compatibility: parse_unit("m/s") with no system= must
         # still resolve via the global registry.
-        from ucon.core import UnitProduct
-        from ucon.resolver import parse_unit
 
         result = parse_unit("m/s")
         self.assertIsInstance(result, UnitProduct)
@@ -501,8 +491,6 @@ class TestCompoundParserSystemRouting(unittest.TestCase):
     def test_system_factor_wins_over_global(self):
         # When a token exists in both ``system.units`` and the global
         # registry, ``system.units`` takes precedence at the factor level.
-        from ucon.resolver import parse_unit
-        from ucon.units import kelvin, meter
 
         class _ShadowingSystem:
             # Map "m" to ``kelvin`` — a deliberately wrong global meaning
@@ -520,9 +508,6 @@ class TestCompoundParserSystemRouting(unittest.TestCase):
     def test_composite_with_exponent_threads_system(self):
         # Exponents inside composites: ensure system.units lookups still
         # work for tokens that carry exponents.
-        from ucon.core import UnitProduct
-        from ucon.resolver import parse_unit
-        from ucon.units import meter, second
 
         class _Sys:
             units = {"widget": meter, "widget2": second}
@@ -550,11 +535,6 @@ class TestCrossBasisArithmetic(unittest.TestCase):
 
         import numpy as np
 
-        from ucon.basis.builtin import SI
-        from ucon.basis.graph import BasisGraph
-        from ucon.basis.transforms import BasisTransform
-        from ucon.basis.types import Basis, BasisComponent
-        from ucon.system import UnitSystem
 
         si_components = tuple(SI)
         combined = Basis(
@@ -588,13 +568,10 @@ class TestCrossBasisArithmetic(unittest.TestCase):
     def test_unify_via_common_combined_basis(self):
         # 3-way unification: vectors in disjoint bases meet in a common
         # combined basis when no direct path exists.
-        from ucon.basis.ops import unify
-        from ucon.dimension import Dimension
 
         sys, currency, combined = self._build_combined_currency_si_system()
         usd_dim = Dimension.from_components(currency, currency=1)
 
-        from ucon.dimension import Dimension as Dim
         currency_vec = usd_dim.vector
         time_vec = Dim.time.vector
 
@@ -605,10 +582,6 @@ class TestCrossBasisArithmetic(unittest.TestCase):
     def test_cross_basis_number_multiply_inside_use(self):
         # The headline acceptance gate: USD * second succeeds inside
         # ``with use(sys):`` when sys.basis_graph embeds both bases.
-        from ucon.core import Number, Unit
-        from ucon.dimension import Dimension
-        from ucon.system import use
-        from ucon.units import second
 
         sys, currency, combined = self._build_combined_currency_si_system()
         usd_dim = Dimension.from_components(currency, currency=1)
@@ -625,10 +598,6 @@ class TestCrossBasisArithmetic(unittest.TestCase):
     def test_cross_basis_number_multiply_outside_use_still_raises(self):
         # When the active system's basis_graph has no transform for the
         # domain basis, cross-basis multiply must still raise.
-        from ucon.basis.types import Basis, BasisComponent, BasisMismatch
-        from ucon.core import Number, Unit
-        from ucon.dimension import Dimension
-        from ucon.units import second
 
         # Use a unique basis name to avoid hits on the algebra cache
         # populated by earlier tests (e.g. test_cross_basis_number_multiply_inside_use).


### PR DESCRIPTION
W0 housekeeping opening the v2.2.0 era: ~1,250 function-local import lines across 39 test files hoisted to module scope per the no-local-imports rule. Spelling-equivalent re-exports normalized to one canonical source (verified by object identity); the two genuinely distinct private helpers named `_get_numpy` (`core._types` vs `maps`) hoist under aliases; `integrations/` keeps its module-level try/except optional-dependency guards unchanged; Net −715 lines. No behavior change: full-suite results are identical on a clean tree vs. this branch.
