### PR TITLE
package-namespace qualification for kinds and aspects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `UnitSystem.adopt()`, `Bridge.apply()`) thread aspects unchanged.
   `resolve_add_aspects` / `resolve_mul_aspects` ship via
   `ucon.aspects`.
+- **D3 namespacing: full qualification + the `namespace` rewriter.**
+  (#285) Package-declared kinds and aspects carry `pkg:name` — aliases
+  included, since an unqualified alias collides across packages exactly
+  the way a name does. The ergonomics are recovered by
+  `rewrite_namespace` (via `ucon.parsing`): `namespace = "pkg"` in
+  `[package]` qualifies every unprefixed declared name and
+  kind-reference (kinds, aspects, formula inputs/outputs, constant
+  kinds); `@name` escapes to root; `pkg:name` spellings pass through
+  as explicit cross-package references. The rewrite is a pure
+  dict→dict transformation that consults nothing loaded (it cannot
+  shadow) and consumes the `namespace` key (it is idempotent, and its
+  output equals the hand-qualified file). Applied automatically by
+  `load_package` and `from_toml`.
+- **Packages can declare aspects.** `[[aspects]]` sections in a
+  package TOML parse into `UnitPackage.aspects`;
+  `ConversionGraph.with_package` merges them into the graph's forest.
+  No silent override: a same-named distinct aspect raises
+  `AspectError` at composition — under qualification, collisions
+  indicate a missing namespace, not a tie to break.
+- **Cross-fiber `NameCollision` now diagnoses itself.** (#285) The
+  flat kind-name index stays in 2.x — coexistence of same-named kinds
+  in different fibers under name-only `Kind.__eq__` would silently
+  conflate them in lattice walks, and extending equality is a breaking
+  change reserved for a major. When a collision spans fibers, the
+  error now names both dimensions and points at `pkg:name`
+  qualification as the supported resolution.
 - **`[[aspects]]` TOML and serialization round-trip.**
   `parse_aspects_payload` / `load_aspects_file` (via `ucon.parsing`)
   build an `AspectForest` from declarations — order-independent parent

--- a/tests/ucon/kinds/test_validation.py
+++ b/tests/ucon/kinds/test_validation.py
@@ -75,6 +75,41 @@ def test_distinct_same_name_objects_raise_name_collision():
     assert exc.value.name == "foo"
 
 
+def test_cross_fiber_collision_diagnoses_and_points_at_qualification():
+    """#285 — the decision of record: the flat name index stays in 2.x.
+
+    Same-named kinds in different fibers stay refused, because letting
+    them coexist under name-only ``Kind.__eq__`` would silently
+    conflate them in every lattice walk (``join`` short-circuits on
+    ``a == b``; ``lca``/``ancestors`` compare by name) — a wrong-answer
+    failure strictly worse than today's loud one. Re-keying the index
+    by ``(name, dimension)`` therefore requires extending ``Kind``
+    equality, a breaking change reserved for a major release. What 2.2.0
+    delivers instead: ``pkg:name`` qualification (which resolves the
+    load-bearing cross-package case) and this diagnostic, which names
+    both fibers and the fix."""
+    a = Kind("dose", dimension=ENERGY_DIM)
+    b = Kind("dose", dimension=POWER_DIM)
+    with pytest.raises(NameCollision) as exc:
+        KindLattice([a, b])
+    err = exc.value
+    assert err.name == "dose"
+    assert err.existing_dimension == ENERGY_DIM
+    assert err.new_dimension == POWER_DIM
+    assert "different fibers" in str(err)
+    assert "pkg:dose" in str(err)
+
+
+def test_same_fiber_collision_message_carries_no_fiber_hint():
+    """Same name, same dimension: a plain duplicate — qualification
+    advice would be misleading, so the message stays as it was."""
+    a = Kind("foo", dimension=ENERGY_DIM)
+    b = Kind("foo", dimension=ENERGY_DIM)
+    with pytest.raises(NameCollision) as exc:
+        KindLattice([a, b])
+    assert "different fibers" not in str(exc.value)
+
+
 # --------- alias collisions ---------
 
 def test_alias_collides_with_other_alias():

--- a/tests/ucon/parsing/test_namespaces.py
+++ b/tests/ucon/parsing/test_namespaces.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The Radiativity Company
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the namespace rewriter (A6 of the aspect stratum, #285).
+
+Full qualification (``pkg:name`` for every package-declared kind and
+aspect, aliases included) is the namespacing rule; the rewriter
+recovers the ergonomics. It is a pure ``dict → dict`` transformation
+that consults nothing loaded — so it cannot shadow — and it consumes
+the ``namespace`` key, which makes it idempotent and its output equal
+to the hand-qualified file.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from ucon.parsing import rewrite_namespace
+
+
+def _payload() -> dict:
+    return {
+        "package": {"name": "radsafe", "namespace": "radsafe"},
+        "kinds": [
+            {"name": "dose_equivalent", "dimension": "L²/T²",
+             "aliases": ["H"]},
+            {"name": "ambient_dose", "dimension": "L²/T²",
+             "parent": "dose_equivalent"},
+            {"name": "exotic_energy", "dimension": "L²·M/T²",
+             "parent": "@energy"},
+        ],
+        "aspects": [
+            {"name": "weighting_standard",
+             "applies_to": ["dose_equivalent", "@energy"]},
+            {"name": "icrp103", "parent": "weighting_standard"},
+            {"name": "coverage", "applies_to": ["*"]},
+        ],
+        "formulas": [
+            {"name": "weighting", "expression": "D * w",
+             "output_kind": "dose_equivalent",
+             "inputs": {"D": {"kind": "@absorbed_dose"},
+                        "w": {"kind": "weighting_factor"}}},
+        ],
+        "constants": [
+            {"symbol": "H_ref", "name": "reference dose", "value": 1.0,
+             "unit": "Sv", "kind": "dose_equivalent"},
+        ],
+    }
+
+
+# --------- qualification ---------
+
+def test_kind_names_parents_and_aliases_qualified():
+    out = rewrite_namespace(_payload())
+    names = [k["name"] for k in out["kinds"]]
+    assert names == ["radsafe:dose_equivalent", "radsafe:ambient_dose",
+                     "radsafe:exotic_energy"]
+    assert out["kinds"][1]["parent"] == "radsafe:dose_equivalent"
+    # aliases included — an unqualified alias would collide across
+    # packages exactly the way an unqualified name would
+    assert out["kinds"][0]["aliases"] == ["radsafe:H"]
+
+
+def test_aspect_names_parents_and_applies_to_qualified():
+    out = rewrite_namespace(_payload())
+    assert out["aspects"][0]["name"] == "radsafe:weighting_standard"
+    assert out["aspects"][1]["parent"] == "radsafe:weighting_standard"
+    assert out["aspects"][0]["applies_to"] == [
+        "radsafe:dose_equivalent", "energy"]
+
+
+def test_wildcard_applies_to_untouched():
+    out = rewrite_namespace(_payload())
+    assert out["aspects"][2]["applies_to"] == ["*"]
+
+
+def test_formula_kind_references_qualified_bindings_untouched():
+    out = rewrite_namespace(_payload())
+    f = out["formulas"][0]
+    assert f["output_kind"] == "radsafe:dose_equivalent"
+    assert set(f["inputs"]) == {"D", "w"}          # binding names local
+    assert f["inputs"]["D"]["kind"] == "absorbed_dose"   # root escape
+    assert f["inputs"]["w"]["kind"] == "radsafe:weighting_factor"
+
+
+def test_constant_kind_reference_qualified():
+    out = rewrite_namespace(_payload())
+    assert out["constants"][0]["kind"] == "radsafe:dose_equivalent"
+
+
+def test_root_escape_strips_at_sign():
+    out = rewrite_namespace(_payload())
+    assert out["kinds"][2]["parent"] == "energy"
+
+
+def test_already_qualified_names_untouched():
+    payload = _payload()
+    payload["kinds"][1]["parent"] = "pharma:dose"   # explicit cross-package
+    out = rewrite_namespace(payload)
+    assert out["kinds"][1]["parent"] == "pharma:dose"
+
+
+def test_units_and_edges_pass_through():
+    payload = _payload()
+    payload["units"] = [{"name": "sievert", "dimension": "specific_energy"}]
+    payload["edges"] = [{"src": "sievert", "dst": "gray", "factor": 1.0}]
+    out = rewrite_namespace(payload)
+    assert out["units"] == payload["units"]
+    assert out["edges"] == payload["edges"]
+
+
+# --------- the vetted properties ---------
+
+def test_idempotent():
+    """The namespace key is consumed, so a second application is the
+    identity."""
+    once = rewrite_namespace(_payload())
+    assert "namespace" not in once["package"]
+    assert rewrite_namespace(once) == once
+
+
+def test_output_equals_hand_qualified_file():
+    """Rewriting the shorthand file yields exactly the dict the
+    hand-qualified file parses to."""
+    hand = {
+        "package": {"name": "radsafe"},
+        "kinds": [
+            {"name": "radsafe:dose_equivalent", "dimension": "L²/T²",
+             "aliases": ["radsafe:H"]},
+            {"name": "radsafe:ambient_dose", "dimension": "L²/T²",
+             "parent": "radsafe:dose_equivalent"},
+            {"name": "radsafe:exotic_energy", "dimension": "L²·M/T²",
+             "parent": "energy"},
+        ],
+        "aspects": [
+            {"name": "radsafe:weighting_standard",
+             "applies_to": ["radsafe:dose_equivalent", "energy"]},
+            {"name": "radsafe:icrp103",
+             "parent": "radsafe:weighting_standard"},
+            {"name": "radsafe:coverage", "applies_to": ["*"]},
+        ],
+        "formulas": [
+            {"name": "weighting", "expression": "D * w",
+             "output_kind": "radsafe:dose_equivalent",
+             "inputs": {"D": {"kind": "absorbed_dose"},
+                        "w": {"kind": "radsafe:weighting_factor"}}},
+        ],
+        "constants": [
+            {"symbol": "H_ref", "name": "reference dose", "value": 1.0,
+             "unit": "Sv", "kind": "radsafe:dose_equivalent"},
+        ],
+    }
+    assert rewrite_namespace(_payload()) == hand
+
+
+def test_pure_input_not_mutated():
+    payload = _payload()
+    snapshot = copy.deepcopy(payload)
+    rewrite_namespace(payload)
+    assert payload == snapshot
+
+
+def test_no_namespace_is_identity():
+    payload = _payload()
+    del payload["package"]["namespace"]
+    assert rewrite_namespace(payload) is payload
+
+
+# --------- namespace value validation ---------
+
+@pytest.mark.parametrize("bad", ["", 7, "a:b", "a@b"])
+def test_invalid_namespace_values_raise(bad):
+    payload = {"package": {"namespace": bad}}
+    with pytest.raises(ValueError):
+        rewrite_namespace(payload)

--- a/tests/ucon/test_packages.py
+++ b/tests/ucon/test_packages.py
@@ -26,6 +26,7 @@ from ucon import (
     UnitDef,
     UnitPackage,
 )
+from ucon.aspects import AspectError
 from ucon.graph import ConversionGraph
 from ucon.maps import AffineMap, ExpMap, LinearMap, LogMap, ReciprocalMap
 from ucon.constants import Constant
@@ -395,6 +396,154 @@ class TestWithPackage(unittest.TestCase):
             meter = parse_unit('m')
             m = graph.convert(src=nmi, dst=meter)
             self.assertAlmostEqual(m(1), 1852, places=0)
+
+
+class TestPackageNamespacing(unittest.TestCase):
+    """D3 full qualification for package vocabularies (#285).
+
+    ``namespace = "pkg"`` in ``[package]`` qualifies every declared
+    kind and aspect (aliases included) at load; two packages sharing
+    an unqualified vocabulary therefore compose without collision —
+    the load-bearing case #285 tracks.
+    """
+
+    RADSAFE = '''
+[package]
+name = "radsafe"
+namespace = "radsafe"
+
+[[kinds]]
+name = "dose"
+dimension = "L²/T²"
+aliases = ["H"]
+
+[[kinds]]
+name = "ambient_dose"
+dimension = "L²/T²"
+parent = "dose"
+
+[[aspects]]
+name = "weighting_standard"
+applies_to = ["dose"]
+
+[[aspects]]
+name = "icrp103"
+parent = "weighting_standard"
+
+[[constants]]
+symbol = "H_ref"
+name = "reference dose"
+value = 1.0
+unit = "joule"
+kind = "dose"
+'''
+
+    PHARMA = '''
+[package]
+name = "pharma"
+namespace = "pharma"
+
+[[kinds]]
+name = "dose"
+dimension = "M"
+aliases = ["H"]
+
+[[aspects]]
+name = "weighting_standard"
+'''
+
+    @staticmethod
+    def _load(toml_content):
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.toml', delete=False
+        ) as f:
+            f.write(toml_content)
+            f.flush()
+            path = Path(f.name)
+        try:
+            return load_package(path)
+        finally:
+            path.unlink()
+
+    def test_kinds_qualified_aliases_included(self):
+        pkg = self._load(self.RADSAFE)
+        self.assertEqual(
+            set(pkg.kinds.names()),
+            {'radsafe:dose', 'radsafe:ambient_dose'},
+        )
+        # aliases qualify too — an unqualified alias would collide
+        # across packages exactly the way an unqualified name would
+        self.assertIn('radsafe:H', pkg.kinds)
+        self.assertEqual(pkg.kinds.get('radsafe:H').name, 'radsafe:dose')
+        self.assertEqual(
+            pkg.kinds.get('radsafe:ambient_dose').parent.name,
+            'radsafe:dose',
+        )
+
+    def test_aspects_qualified_with_applies_to(self):
+        pkg = self._load(self.RADSAFE)
+        self.assertIn('radsafe:weighting_standard', pkg.aspects)
+        icrp = pkg.aspects.get('radsafe:icrp103')
+        self.assertEqual(icrp.parent.name, 'radsafe:weighting_standard')
+        self.assertEqual(
+            pkg.aspects.get('radsafe:weighting_standard').applies_to,
+            frozenset({'radsafe:dose'}),
+        )
+
+    def test_constant_kind_reference_qualified(self):
+        pkg = self._load(self.RADSAFE)
+        self.assertEqual(pkg.constants[0].kind, 'radsafe:dose')
+
+    def test_invalid_namespace_raises_package_load_error(self):
+        bad = '[package]\nname = "x"\nnamespace = "a:b"\n'
+        with self.assertRaises(PackageLoadError) as ctx:
+            self._load(bad)
+        self.assertIn('namespace', str(ctx.exception))
+
+    def test_invalid_aspects_raise_package_load_error(self):
+        bad = '''
+[package]
+name = "x"
+
+[[aspects]]
+name = "child"
+parent = "ghost"
+'''
+        with self.assertRaises(PackageLoadError) as ctx:
+            self._load(bad)
+        self.assertIn('[[aspects]]', str(ctx.exception))
+
+    def test_same_vocabulary_packages_compose(self):
+        """The #285 payoff: radsafe:dose (specific energy) and
+        pharma:dose (mass) — plus their shared alias 'H' — coexist
+        because qualification separates them in the flat index."""
+        radsafe = self._load(self.RADSAFE)
+        pharma = self._load(self.PHARMA)
+        graph = get_default_graph().with_package(radsafe).with_package(pharma)
+        self.assertIn('radsafe:dose', graph._kind_lattice)
+        self.assertIn('pharma:dose', graph._kind_lattice)
+        self.assertIn('radsafe:H', graph._kind_lattice)
+        self.assertIn('pharma:H', graph._kind_lattice)
+        self.assertIn('radsafe:weighting_standard', graph._aspect_forest)
+        self.assertIn('pharma:weighting_standard', graph._aspect_forest)
+
+    def test_with_package_aspects_do_not_mutate_original(self):
+        pkg = self._load(self.RADSAFE)
+        base = get_default_graph()
+        base_forest = base._aspect_forest
+        extended = base.with_package(pkg)
+        self.assertIn('radsafe:icrp103', extended._aspect_forest)
+        self.assertIs(base._aspect_forest, base_forest)
+
+    def test_unqualified_aspect_collision_is_loud(self):
+        """Without namespaces, same-named aspect declarations refuse at
+        composition — no silent override. (Kinds are omitted here; the
+        kind layer raises its own collision first when present.)"""
+        template = '[package]\nname = "{n}"\n\n[[aspects]]\nname = "weighting_standard"\n'
+        a = self._load(template.format(n='a'))
+        b = self._load(template.format(n='b'))
+        with self.assertRaises(AspectError):
+            get_default_graph().with_package(a).with_package(b)
 
 
 class TestParseFactorEdgeCases(unittest.TestCase):

--- a/tests/ucon/test_serialization.py
+++ b/tests/ucon/test_serialization.py
@@ -2945,6 +2945,32 @@ class TestAspectsSerialization:
         restored.to_toml(second)   # forest comes from graph._aspect_forest
         assert _collect_aspects(restored, None) == _collect_aspects(None, forest)
 
+    def test_from_toml_applies_namespace_shorthand(self, tmp_path):
+        """A hand-authored file may declare package.namespace; from_toml
+        qualifies kinds and aspects before parsing (#285). to_toml never
+        emits the shorthand, so round-trips stay fully qualified."""
+        source = tmp_path / "shorthand.ucon.toml"
+        source.write_text(
+            '[package]\n'
+            'name = "radsafe"\n'
+            'format_version = "1.0"\n'
+            'namespace = "radsafe"\n'
+            '\n'
+            '[[kinds]]\n'
+            'name = "dose"\n'
+            'dimension = "L²/T²"\n'
+            '\n'
+            '[[aspects]]\n'
+            'name = "weighting_standard"\n'
+            'applies_to = ["dose"]\n'
+        )
+        restored = from_toml(source)
+        assert set(restored._kind_lattice.names()) == {"radsafe:dose"}
+        forest = restored._aspect_forest
+        assert "radsafe:weighting_standard" in forest
+        assert forest.get("radsafe:weighting_standard").applies_to == \
+            frozenset({"radsafe:dose"})
+
 
 class TestFormulasSerialization:
     """Tests for formula TOML round-trip (v2.1.0)."""

--- a/ucon/conversion.py
+++ b/ucon/conversion.py
@@ -53,6 +53,7 @@ from ucon.core import (
     Scale,
     UnknownUnitError,
 )
+from ucon.aspects import AspectForest as _AspectForest
 from ucon.core._parsing_graph import _parsing_graph
 from ucon.kinds import KindLattice as _KindLattice
 from ucon.maps import Map, LinearMap, AffineMap, LogMap
@@ -664,6 +665,19 @@ class Graph:
                 new._kind_lattice = merged
             else:
                 new._kind_lattice = package.kinds
+
+        # Merge aspect forest. No silent override: qualified names make
+        # cross-package overlap structurally unlikely, so a same-named
+        # distinct node is a declaration error and the forest's own
+        # duplicate-name validation raises AspectError loudly.
+        if package.aspects is not None and len(package.aspects) > 0:
+            existing_forest = self._aspect_forest
+            if existing_forest is not None and len(existing_forest) > 0:
+                new._aspect_forest = _AspectForest(
+                    list(existing_forest) + list(package.aspects)
+                )
+            else:
+                new._aspect_forest = package.aspects
 
         # Materialize constants (resolved within new graph context).
         # Pass the merged kind lattice so novel kinds defined by the

--- a/ucon/kinds/exceptions.py
+++ b/ucon/kinds/exceptions.py
@@ -84,11 +84,40 @@ class CrossDimensionParent(KindError):
 
 
 class NameCollision(KindError):
-    """Two kinds share the same primary name."""
+    """Two kinds share the same primary name.
 
-    def __init__(self, name: str) -> None:
+    When the colliding kinds live in different fibers (their dimensions
+    differ), the message says so and points at qualification: the flat
+    name index refuses cross-fiber same-names in 2.x because name-only
+    ``Kind.__eq__`` would make lattice walks silently conflate them if
+    they coexisted. Extending equality is a breaking change reserved
+    for a major release; ``pkg:name`` qualification is the supported
+    resolution today.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        existing_dimension: 'object | None' = None,
+        new_dimension: 'object | None' = None,
+    ) -> None:
         self.name = name
-        super().__init__(f"Duplicate kind name: {name!r}")
+        self.existing_dimension = existing_dimension
+        self.new_dimension = new_dimension
+        message = f"Duplicate kind name: {name!r}"
+        if (
+            existing_dimension is not None
+            and new_dimension is not None
+            and existing_dimension != new_dimension
+        ):
+            message += (
+                f" — the kinds occupy different fibers "
+                f"({existing_dimension} vs {new_dimension}); the flat "
+                f"name index cannot host both. Qualify the names "
+                f"(e.g. 'pkg:{name}') to disambiguate."
+            )
+        super().__init__(message)
 
 
 class AliasCollision(KindError):

--- a/ucon/kinds/lattice.py
+++ b/ucon/kinds/lattice.py
@@ -84,7 +84,11 @@ class KindLattice:
             if existing is kind:
                 return
             if existing.name == kind.name:
-                raise NameCollision(kind.name)
+                raise NameCollision(
+                    kind.name,
+                    existing_dimension=existing.dimension,
+                    new_dimension=kind.dimension,
+                )
             raise AliasCollision(kind.name, existing.name)
         self._by_name[kind.name] = kind
         self._index[kind.name] = kind

--- a/ucon/packages.py
+++ b/ucon/packages.py
@@ -50,6 +50,7 @@ import ast
 import operator
 import unicodedata
 
+from ucon.aspects import AspectError, AspectForest
 from ucon.constants import Constant
 from ucon.core import Unit, UnknownUnitError
 from ucon.dimension import Dimension, all_dimensions
@@ -57,7 +58,9 @@ from ucon.graph import using_conversion_graph
 from ucon.kinds import KindLattice
 from ucon.kinds.exceptions import KindNotFound
 from ucon.maps import AffineMap, LinearMap, Map
+from ucon.parsing.aspects import parse_aspects_payload
 from ucon.parsing.kinds import parse_kinds_payload
+from ucon.parsing.namespaces import rewrite_namespace
 from ucon.resolver import parse_unit
 from ucon.system import active_kinds
 
@@ -514,6 +517,9 @@ class UnitPackage:
     kinds : KindLattice | None
         Kind-of-quantity lattice parsed from ``[[kinds]]`` sections.
         ``None`` when the package does not define any kinds.
+    aspects : AspectForest | None
+        Aspect forest parsed from ``[[aspects]]`` sections. ``None``
+        when the package does not declare any aspects.
     requires : tuple[str, ...]
         Names of required packages (for future dependency resolution).
     """
@@ -524,6 +530,7 @@ class UnitPackage:
     edges: tuple[EdgeDef, ...] = ()
     constants: tuple[ConstantDef, ...] = ()
     kinds: KindLattice | None = None
+    aspects: AspectForest | None = None
     requires: tuple[str, ...] = ()
 
     def __post_init__(self):
@@ -571,6 +578,14 @@ def load_package(path: str | Path) -> UnitPackage:
         raise PackageLoadError(f"Package file not found: {path}")
     except tomllib.TOMLDecodeError as e:
         raise PackageLoadError(f"Invalid TOML in {path}: {e}")
+
+    # Apply the namespace rewriter before any section is parsed, so
+    # kinds, aspects, formulas, and constant kind-references all see
+    # the fully qualified names the hand-written equivalent would carry.
+    try:
+        data = rewrite_namespace(data)
+    except ValueError as e:
+        raise PackageLoadError(f"Invalid namespace in {path}: {e}")
 
     # Parse units
     units = tuple(
@@ -640,6 +655,14 @@ def load_package(path: str | Path) -> UnitPackage:
         except (ValueError, Exception) as e:
             raise PackageLoadError(f"Invalid [[kinds]] in {path}: {e}")
 
+    # Parse aspects
+    aspects: AspectForest | None = None
+    if "aspects" in data:
+        try:
+            aspects = parse_aspects_payload(data)
+        except (ValueError, AspectError) as e:
+            raise PackageLoadError(f"Invalid [[aspects]] in {path}: {e}")
+
     # Support both [package] table (preferred) and top-level keys (legacy)
     package = data.get("package", {})
 
@@ -651,6 +674,7 @@ def load_package(path: str | Path) -> UnitPackage:
         edges=edges,
         constants=constants,
         kinds=kinds,
+        aspects=aspects,
         requires=tuple(package.get("requires", data.get("requires", []))),
     )
 

--- a/ucon/parsing/__init__.py
+++ b/ucon/parsing/__init__.py
@@ -54,6 +54,7 @@ _LAZY = {
     "load_formulas_file": ("ucon.parsing.formulas", "load_formulas_file"),
     "parse_aspects_payload": ("ucon.parsing.aspects", "parse_aspects_payload"),
     "load_aspects_file": ("ucon.parsing.aspects", "load_aspects_file"),
+    "rewrite_namespace": ("ucon.parsing.namespaces", "rewrite_namespace"),
 }
 
 
@@ -89,4 +90,5 @@ __all__ = [
     "load_formulas_file",
     "parse_aspects_payload",
     "load_aspects_file",
+    "rewrite_namespace",
 ]

--- a/ucon/parsing/namespaces.py
+++ b/ucon/parsing/namespaces.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The Radiativity Company
+# Licensed under the Apache License, Version 2.0
+
+"""
+The ``namespace`` rewriter: full qualification without the typing.
+
+Full qualification is the namespacing rule for package-declared
+vocabulary: ``pkg:name`` for every kind and aspect a package declares,
+aliases included; root builtins stay unprefixed; cross-package
+references are written explicitly. A per-package *default scope* was
+considered and declined — it needs a resolution rule that silently
+shadows a root builtin when a package reuses its name. Design record:
+``docs/internal/decisions/008-aspect-stratum.md``.
+
+The verbosity is recovered here. A package sets::
+
+    [package]
+    name = "radsafe"
+    namespace = "radsafe"
+
+and writes unprefixed names; :func:`rewrite_namespace` prepends the
+prefix to every unprefixed declared name and kind-reference in the
+payload, producing exactly the dict the hand-qualified file would have
+parsed to. Three spellings control the rewrite:
+
+* ``name`` — unprefixed, becomes ``pkg:name``.
+* ``pkg:name`` — already qualified (any prefix), left untouched; this
+  is also how cross-package references are written.
+* ``@name`` — root escape: refers to (or declares) the unqualified
+  root name; the ``@`` is stripped and no prefix is applied.
+
+The rewrite is a pure ``dict → dict`` transformation: it consults
+nothing loaded — no registry, no active system — and therefore cannot
+shadow anything. It is idempotent because the ``namespace`` key is
+consumed: the output carries no ``namespace``, so a second application
+is the identity (and the output equals the hand-qualified file, which
+has no ``namespace`` key either).
+
+Rewritten positions
+-------------------
+* ``[[kinds]]`` — ``name``, ``parent``, every ``aliases`` entry.
+* ``[[aspects]]`` — ``name``, ``parent``, every ``applies_to`` entry
+  (kind references; the ``"*"`` wildcard passes through untouched).
+* ``[[formulas]]`` — ``output_kind`` and each ``inputs.<binding>.kind``
+  (binding names are local to the formula and are not rewritten).
+* ``[[constants]]`` — the optional ``kind`` reference.
+
+Everything else (units, edges, dimensions, transforms) is out of the
+qualification surface and passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+
+__all__ = ["rewrite_namespace"]
+
+
+def _qualify(name: str, prefix: str) -> str:
+    """Apply the three-spelling rule to one name."""
+    if name.startswith("@"):
+        return name[1:]
+    if ":" in name:
+        return name
+    return f"{prefix}:{name}"
+
+
+def rewrite_namespace(payload: dict[str, Any]) -> dict[str, Any]:
+    """Qualify a payload's declared names per its ``package.namespace``.
+
+    Parameters
+    ----------
+    payload
+        The dict produced by :func:`tomllib.load`.
+
+    Returns
+    -------
+    dict
+        When the payload carries no ``package.namespace``: the payload
+        itself, unchanged. Otherwise a deep-copied payload with every
+        unprefixed kind/aspect name and kind-reference qualified and
+        the ``namespace`` key removed (which is what makes the
+        transformation idempotent).
+
+    Raises
+    ------
+    ValueError
+        If ``namespace`` is not a nonempty string, or contains ``:``
+        or ``@`` (a prefix must itself be an unqualified name).
+    """
+    package = payload.get("package")
+    if not isinstance(package, dict) or "namespace" not in package:
+        return payload
+
+    prefix = package["namespace"]
+    if not isinstance(prefix, str) or not prefix:
+        raise ValueError(
+            f"package.namespace must be a nonempty string, got {prefix!r}"
+        )
+    if ":" in prefix or "@" in prefix:
+        raise ValueError(
+            f"package.namespace {prefix!r} may not contain ':' or '@'"
+        )
+
+    out = copy.deepcopy(payload)
+    del out["package"]["namespace"]
+
+    for entry in out.get("kinds", []):
+        if "name" in entry:
+            entry["name"] = _qualify(entry["name"], prefix)
+        if "parent" in entry:
+            entry["parent"] = _qualify(entry["parent"], prefix)
+        if "aliases" in entry:
+            entry["aliases"] = [
+                _qualify(alias, prefix) for alias in entry["aliases"]
+            ]
+
+    for entry in out.get("aspects", []):
+        if "name" in entry:
+            entry["name"] = _qualify(entry["name"], prefix)
+        if "parent" in entry:
+            entry["parent"] = _qualify(entry["parent"], prefix)
+        if "applies_to" in entry:
+            entry["applies_to"] = [
+                kind if kind == "*" else _qualify(kind, prefix)
+                for kind in entry["applies_to"]
+            ]
+
+    for entry in out.get("formulas", []):
+        if "output_kind" in entry:
+            entry["output_kind"] = _qualify(entry["output_kind"], prefix)
+        inputs = entry.get("inputs")
+        if isinstance(inputs, dict):
+            for spec in inputs.values():
+                if isinstance(spec, dict) and "kind" in spec:
+                    spec["kind"] = _qualify(spec["kind"], prefix)
+
+    for entry in out.get("constants", []):
+        if "kind" in entry:
+            entry["kind"] = _qualify(entry["kind"], prefix)
+
+    return out

--- a/ucon/serialization.py
+++ b/ucon/serialization.py
@@ -52,6 +52,7 @@ from ucon.kinds.exceptions import KindNotFound
 from ucon.parsing.aspects import parse_aspects_payload
 from ucon.parsing.formulas import parse_formulas_payload
 from ucon.parsing.kinds import parse_kinds_payload
+from ucon.parsing.namespaces import rewrite_namespace
 from ucon.maps import (
     AffineMap,
     LinearMap,
@@ -817,6 +818,11 @@ def from_toml(path: Union[str, Path], *, strict: bool = True):
         doc = tomllib.load(f)
 
     _check_format_version(doc)
+
+    # Apply the namespace rewriter (no-op without package.namespace) so
+    # hand-authored files may use the shorthand; to_toml always emits
+    # fully qualified names and never emits a namespace key.
+    doc = rewrite_namespace(doc)
 
     # 1. Build bases
     basis_map: dict[str, Basis] = {}


### PR DESCRIPTION
Closes #285

Full D3 qualification per [decisions/008](docs/internal/decisions/008-aspect-stratum.md): package-declared kinds and aspects qualify as `pkg:name` so same-named quantities from different domains coexist instead of colliding.

## What ships

- **The namespace rewriter** — `rewrite_namespace` (`ucon/parsing/namespaces.py`, exported via `ucon.parsing`): pure dict→dict. With `namespace = "pkg"` in `[package]`, every unprefixed declared name and kind-reference qualifies — `[[kinds]]` name/parent/aliases, `[[aspects]]` name/parent/`applies_to` (wildcard `*` untouched), `[[formulas]]` output and input kinds (binding names stay local), `[[constants]]` kind. `@name` escapes to root; explicit `pkg:name` spellings pass through. Idempotent: the output equals the hand-qualified file.
- **Loader wiring** — `load_package` and `from_toml` apply the rewriter before any section parses; packages can declare `[[aspects]]` (`UnitPackage.aspects`); forest merges refuse same-named distinct aspects loudly — under qualification a collision means a missing namespace, not a tie to break. `to_toml` output stays fully qualified.
- **The `(name, dimension)` index decision** — the flat index stays in 2.x. Coexistence under name-only `Kind` equality would silently conflate same-named cross-fiber kinds in every lattice walk (`join` short-circuits on equality) — a wrong-answer failure strictly worse than today's loud one; re-keying requires extending `Kind.__eq__`, which is major-only. Instead, `NameCollision` now names both fibers and points at `pkg:name` qualification when the dimensions differ.

The R4 payoff scenario runs as a test: `radsafe:dose` (L²/T²) and `pharma:dose` (M) with a shared alias `H` compose without collision.

Suite: 3084 passed.
