### PR TITLE
2.2.0 release notes and documentation alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-12
+
 ### Removed
 
 - **The flat aspect model, outright.** `AspectSet`, `AspectJoinPolicy`,
@@ -116,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to v2.3.0.** Release reassignment per
   [decisions/008](docs/internal/decisions/008-aspect-stratum.md) and
   [ROADMAP.md](ROADMAP.md). The never-exported flat `AspectSet` model
-  will be removed outright with the stratum's arrival (it was never
+  is removed outright with the stratum's arrival in this release (it
+  was never
   public: no aspect symbol has ever shipped through
   `ucon/__init__.py`).
 
@@ -2803,6 +2806,7 @@ Deprecated surfaces are scheduled for removal in v2.0.
 - Initial commit
 
 <!-- Links -->
+[2.2.0]: https://github.com/withtwoemms/ucon/compare/2.1.7...2.2.0
 [2.1.7]: https://github.com/withtwoemms/ucon/compare/2.1.6...2.1.7
 [2.1.6]: https://github.com/withtwoemms/ucon/compare/2.1.5...2.1.6
 [2.1.5]: https://github.com/withtwoemms/ucon/compare/2.1.4...2.1.5

--- a/docs/architecture/kind-of-quantity.md
+++ b/docs/architecture/kind-of-quantity.md
@@ -138,6 +138,14 @@ flowchart LR
 
 ## Solution 1: Pseudo-Dimensions
 
+!!! warning "Deprecated"
+    Pseudo-dimensions are deprecated as of v2.2.0 and will be removed in
+    3.0.0. `Dimension.pseudo(...)` emits `PendingDeprecationWarning`.
+    Migrate to a `Kind` over the dimensionless dimension — kinds carry
+    the semantic isolation pseudo-dimensions approximate, and
+    participate in lattice joins and formula dispatch (Solution 3).
+
+
 For quantities that are mathematically dimensionless but physically distinct,
 ucon provides **pseudo-dimensions**:
 
@@ -404,120 +412,104 @@ result.match_kind  # MatchKind.GENERALIZED
 result.distance    # 1 (kinetic_energy → energy = 1 climb)
 ```
 
-### Aspect Propagation
+### The Aspect Stratum
 
-Kinds tell you *what* a quantity is; **aspects** tell you *something about*
-a quantity — that it was reduced from many measurements, that it was
-calibrated against a reference, that it represents a signal summary.
-Aspects are covariant tags (strings) carried alongside a quantity,
-orthogonal to kinds: two values with the same kind can differ in aspects,
-and two values with different kinds can share aspects.
+Kinds tell you *what* a quantity is; **aspects** qualify it on terms the
+kind cannot express — the weighting standard behind a dose equivalent,
+the dry/wet basis of a mass fraction, the coverage factor on an expanded
+uncertainty. Two values with the same dimension, unit, *and* kind may
+still refuse to combine.
 
-Aspects matter at two sites in the algebra:
+Aspects are tree nodes, peers of `Kind`. The root of a tree *is* the
+family; children are positions within it:
 
-1. **Multiplication (formula application)** — the formula's `aspect_rules`
-   controls which operand aspects propagate to the output.
-2. **Addition (lattice join)** — the `AspectJoinPolicy` chosen by the
-   caller controls how aspects from two operands combine.
+```python
+from ucon import Aspect, Number, units
 
-#### Formula Rules: CONSUME and CARRY
+family  = Aspect("weighting_standard",
+                 applies_to=frozenset({"dose_equivalent"}))
+icrp60  = Aspect("icrp60",  parent=family)
+icrp103 = Aspect("icrp103", parent=family)
 
-Each binding in a `KindFormula` can declare an `AspectRule`:
+a = Number(2.0, units.gray, kind=dose_eq, aspects=[icrp103])
+b = Number(3.0, units.gray, kind=dose_eq, aspects=[icrp60])
+a + b   # AspectRefused — the kind stratum cannot see this difference
+```
 
-| Rule | Behaviour |
-|------|-----------|
-| `CARRY` (default) | The operand's aspects are unioned into the output |
-| `CONSUME` | The operand's aspects are dropped |
+#### Family-Wise Resolution
 
-Bindings not mentioned in `aspect_rules` default to `CARRY` — the
-conservative choice is to preserve information; authors opt into dropping
-it.
+Both operands' aspects group by family root; each family resolves
+independently, and cross-family comparison never happens:
+
+- **Equal** positions carry through unchanged.
+- **Differing** positions join at their lowest common ancestor, honoring
+  the ancestor's `join_policy` — `refuse` (the aspect default) raises
+  `AspectRefused`; `lca` carries the ancestor.
+- **Partial** presence (one operand silent in a family) splits by
+  operation: addition consults the ambient strict bit (strict refuses —
+  silence is not agreement; permissive inherits with a warning), while
+  multiplication follows the family's `multiplication_policy`.
 
 ```mermaid
 flowchart LR
     subgraph inputs ["Inputs"]
-        D["D: absorbed_dose<br/><b>aspects:</b> signal_summary"]
-        wR["w_R: weighting_factor<br/><b>aspects:</b> calibrated"]
+        D["absorbed dose (Gy)<br/><b>aspects:</b> —"]
+        wR["w_R: weighting factor<br/><b>aspects:</b> #icrp103"]
     end
 
-    subgraph formula ["Formula: H = D * w_R"]
-        rule_D["D → CARRY"]
-        rule_wR["w_R → CONSUME"]
+    subgraph carry ["× : the carry rule"]
+        rule["weighting_standard → carry"]
     end
 
     subgraph output ["Output"]
-        H["H: equivalent_dose<br/><b>aspects:</b> signal_summary"]
+        H["dose equivalent (Sv)<br/><b>aspects:</b> #icrp103"]
     end
 
-    D --> rule_D --> H
-    wR --> rule_wR
+    D --> rule --> H
+    wR --> rule
 ```
 
-In code:
+#### The Carry Rule
+
+Under multiplication a factor's provenance rides the product — even when
+the product's *kind* degrades. This is what keeps refusals alive through
+round trips:
 
 ```python
-from ucon.aspects import AspectRule, AspectSet
-from ucon.formulas import KindFormula, FormulaRegistry
-
-f = KindFormula(
-    name="radiation_weighting",
-    expression="D * w_R",
-    input_kinds={"D": absorbed_dose, "w_R": weighting_factor},
-    output_kind=equivalent_dose,
-    aspect_rules={"w_R": AspectRule.CONSUME},  # D defaults to CARRY
-)
-reg = FormulaRegistry([f])
-
-formula, out_kind, out_aspects, match_kind = reg.apply({
-    "D":   (absorbed_dose,      AspectSet("signal_summary")),
-    "w_R": (weighting_factor,   AspectSet("calibrated")),
-})
-# out_kind    == equivalent_dose
-# out_aspects == frozenset({"signal_summary"})  — w_R's aspects consumed
-# match_kind  == MatchKind.EXACT
+p60  = a60 * t      # kind may degrade; #icrp60 carried
+p103 = a103 * t     # #icrp103 carried
+p60 + p103          # AspectRefused — the verdict never depended on kinds
 ```
 
-#### Lattice Join: AspectJoinPolicy
+There is no `drop`: no resolution path silently discards a position.
+Aspect resolution reads only the operand aspect sets and the strict
+bit — kind values never influence an aspect verdict (mock every kind to
+garbage and every verdict is unchanged; the test suite pins exactly
+this).
 
-When two quantities with different kinds are added, the kind lattice
-computes the LCA. A separate, pure operation combines the aspect sets:
+#### Attachment
 
-| Policy | Behaviour | Default |
-|--------|-----------|---------|
-| `INTERSECT` | Keep only aspects present on **both** sides | Yes |
-| `UNION` | Keep every aspect from **either** side | No |
-
-`INTERSECT` is the default because addition crosses kinds: the LCA result
-is less specific than either operand, so unshared aspects cannot be
-honestly attributed to the result.
-
-```python
-from ucon.aspects import join_aspects, AspectJoinPolicy
-
-out = join_aspects(
-    AspectSet("signal_summary", "calibrated"),
-    AspectSet("signal_summary"),
-)
-# out == frozenset({"signal_summary"})   (INTERSECT default)
-
-out = join_aspects(
-    AspectSet("signal_summary", "calibrated"),
-    AspectSet("signal_summary"),
-    policy=AspectJoinPolicy.UNION,
-)
-# out == frozenset({"signal_summary", "calibrated"})
-```
+`applies_to` on a family root restricts which kinds the family may
+attach to, checked once at `Number(...)` construction — the aspect
+layer's one sanctioned kind-read. A weighting standard claimed on an
+absorbed dose refuses at the moment the false claim is made
+(`AspectNotApplicable`). Empty `applies_to` means unrestricted; `{"*"}`
+attaches kind-independently (coverage factors on unkinded numbers).
 
 #### Status
 
-In v2.0, kinds and aspects are wired into `Number` arithmetic:
+As of v2.2.0 the aspect stratum is first-class:
 
-- `Kind` and `KindLattice` are re-exported from the top-level `ucon` package.
-- `Number` carries an optional `kind` field, validated at construction.
-- Multiplication and division consult the active `FormulaRegistry` for kind dispatch.
-- Addition and subtraction consult the active `KindLattice` for join semantics.
-- `FormulaRegistry.apply` is the single entry point that combines formula
-  lookup with aspect projection.
+- `Aspect`, `AspectError`, `AspectRefused`, and `AspectNotApplicable`
+  are exported from the top-level `ucon` package.
+- `Number` carries an additive `aspects` frozenset; family-wise
+  resolution is wired into `+ − × ÷`, and single-operand operations
+  thread aspects unchanged.
+- Formulas do kind work only: `FormulaRegistry.apply` takes kinds and
+  returns `(formula, output_kind, match_kind)`. The earlier flat
+  aspect-set model and formula projection machinery were removed.
+- `[[aspects]]` TOML declarations load via `load_aspects_file` and
+  round-trip through graph serialization.
 
 ### TOML Authoring
 
@@ -550,7 +542,7 @@ w_R = { kind = "radiation_weighting_factor" }
 
 ### Status
 
-Kinds, formulas, and aspects are first-class in v2.0:
+Kinds and formulas are first-class as of v2.0, aspects as of v2.2.0:
 
 - `Kind`, `KindLattice`, `FormulaRegistry`, and `ActiveContext` are
   re-exported from the top-level `ucon` package.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -892,6 +892,31 @@ source = "ISA standard atmosphere"
 category = "exact"
 ```
 
+### Schema: `[[aspects]]`
+
+```toml
+[[aspects]]
+name = "weighting_standard"
+applies_to = ["dose_equivalent"]   # root-only
+join_policy = "refuse"             # default for aspects
+
+[[aspects]]
+name = "icrp103"
+parent = "weighting_standard"
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | string | yes | Canonical aspect name |
+| `parent` | string | no | Name of another entry (declaration order is free); absent marks a family root |
+| `join_policy` | string | no | `"refuse"` (default) or `"lca"` |
+| `applies_to` | array of strings | no | **Root-only.** Kind names the family attaches to; `["*"]` = wildcard |
+| `multiplication_policy` | string | no | **Root-only.** `"carry"` (default) |
+
+Root-only keys on a child entry are a load-time `AspectError`. Schema
+faults (missing `name`, wrong types, unknown policies) raise
+`ValueError`.
+
 ### Loading
 
 ```python
@@ -1495,18 +1520,17 @@ from ucon.kinds import (
 
 ## Formulas
 
-Kind-formula dispatch for multiplication and division. Aspect rules control
-propagation (see [Aspects](#aspects) below).
+Kind-formula dispatch for multiplication and division. Formulas do kind
+work only; aspect propagation is handled by the aspect stratum's carry
+rule (see [Aspects](#aspects) below).
 
 A `FormulaRegistry` records named relationships between input kinds and an
-output kind. Given a sequence of `Kind` instances, the registry can resolve
-the formula that produces the corresponding output — and, as of v1.9.1,
-project aspect sets through the formula's rules in one step via `apply`.
+output kind. Given a sequence of `Kind` instances, the registry resolves
+the formula that produces the corresponding output.
 
 ```python
 from ucon.formulas import (
     KindFormula,
-    AspectRule,
     FormulaRegistry,
 )
 ```
@@ -1517,7 +1541,7 @@ Frozen dataclass describing a single relationship:
 
 ```python
 from ucon.kinds import Kind
-from ucon.formulas import AspectRule, KindFormula
+from ucon.formulas import KindFormula
 from ucon.dimension import LENGTH, MASS, TIME
 
 ABSORBED_DOSE_DIM = (LENGTH ** 2) / (TIME ** 2)
@@ -1533,7 +1557,6 @@ f = KindFormula(
     input_kinds={"D": D, "w_R": wR},
     output_kind=H,
     commutative=True,
-    aspect_rules={"w_R": AspectRule.CONSUME},
     notes="w_R per ICRP 103; caller selects.",
 )
 ```
@@ -1544,47 +1567,12 @@ f = KindFormula(
 | `expression` | str | required | Free-form expression string (e.g. `"D * w_R"`) |
 | `input_kinds` | dict[str, Kind] | required | Named inputs in declaration order |
 | `output_kind` | Kind | required | Kind of the resulting quantity |
-| `aspect_rules` | dict[str, AspectRule] | `{}` | Per-binding propagation rules (keys are binding names from `input_kinds`; see [Aspects](#aspects)) |
 | `generalizes` | bool | `False` | Reserved; effective in v1.9.2 |
 | `commutative` | bool | `True` | Two-input formulas are mirrored on registration |
 | `notes` | str | `""` | Free-form annotation |
 
 Equality and hash key off `name` only. `input_kind_tuple()` returns the
 kinds in insertion order.
-
-### AspectRule
-
-Enum classifying how a formula treats an operand's aspects. Declared per
-binding name in `KindFormula.aspect_rules`. Bindings not mentioned default
-to `CARRY`. The canonical import is `from ucon.aspects import AspectRule`;
-the v1.9.0 path `from ucon.formulas import AspectRule` continues to work.
-
-| Member | String value | Meaning |
-|--------|--------------|---------|
-| `AspectRule.CONSUME` | `"consume"` | The binding's aspects are dropped from the output |
-| `AspectRule.CARRY` | `"carry"` | The binding's aspects are unioned into the output |
-
-See [Aspects](#aspects) for the full propagation model.
-
-### `KindFormula.project_aspects(inputs)`
-
-Pure method that projects input aspect sets through this formula's
-`aspect_rules`, returning the output `AspectSet`. Called internally by
-`FormulaRegistry.apply`.
-
-```python
-aspects = f.project_aspects({
-    "D":   frozenset({"signal_summary"}),
-    "w_R": frozenset({"calibrated"}),
-})
-# aspects == frozenset({"signal_summary"})  — w_R consumed
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `inputs` | Mapping[str, AspectSet] | Map of binding names to aspect sets |
-
-Returns `AspectSet` (the union of all carried inputs' aspects).
 
 ### FormulaRegistry
 
@@ -1609,7 +1597,7 @@ reg.names()                           # ('radiation_weighting',)
 | `get(name)` | Return the named formula or raise `FormulaNotFound` |
 | `lookup(*kinds)` | Resolve a formula by exact input-kind tuple |
 | `resolve(*kinds)` | Tiered formula resolution returning `LookupResult` (v1.9.2) |
-| `apply(inputs)` | Resolve formula **and** project aspects in one step (v1.9.1, extended v1.9.2) |
+| `apply(inputs)` | Resolve a formula from named kind bindings in one step |
 | `names()` | Tuple of registered names |
 
 Commutative formulas are indexed under both the original key and a
@@ -1653,33 +1641,28 @@ at the same GENERALIZED distance.
 
 #### `apply(inputs, *, lattice=None, dimension_fallback=False)`
 
-New in v1.9.1, extended in v1.9.2. Single entry point that resolves the
-formula by input kinds and projects aspect sets through it:
+Single entry point that resolves a formula from named kind bindings.
+As of v2.2.0 formulas do kind work only — aspect propagation is the
+aspect stratum's carry rule (see [Aspects](#aspects)):
 
 ```python
-from ucon.aspects import AspectSet
 from ucon.formulas import MatchKind
 
-formula, out_kind, out_aspects, match_kind = reg.apply({
-    "D":   (D,  AspectSet("signal_summary")),
-    "w_R": (wR, AspectSet("calibrated")),
-})
-# formula     == <KindFormula "radiation_weighting">
-# out_kind    == H (equivalent_dose)
-# out_aspects == frozenset({"signal_summary"})
-# match_kind  == MatchKind.EXACT
+formula, out_kind, match_kind = reg.apply({"D": D, "w_R": wR})
+# formula    == <KindFormula "radiation_weighting">
+# out_kind   == H (equivalent_dose)
+# match_kind == MatchKind.EXACT
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `inputs` | Mapping[str, tuple[Kind, AspectSet]] | Map of binding names to (kind, aspects) pairs |
+| `inputs` | Mapping[str, Kind] | Map of binding names to kinds |
 | `lattice` | KindLattice \| None | Enables GENERALIZED matching via ancestor walk |
 | `dimension_fallback` | bool | Enables DIMENSIONAL matching as a last resort |
 
-Returns `tuple[KindFormula, Kind, AspectSet, MatchKind]`. Raises
-`FormulaNotFound` if no formula matches the input kinds, or
-`AmbiguousFormula` if multiple formulas match at the same GENERALIZED
-distance.
+Returns `tuple[KindFormula, Kind, MatchKind]`. Raises `FormulaNotFound`
+if no formula matches the input kinds, or `AmbiguousFormula` if multiple
+formulas match at the same GENERALIZED distance.
 
 ### Types
 
@@ -1715,95 +1698,148 @@ from ucon.formulas import (
 
 ## Aspects
 
-An *aspect* is a covariant tag (a string) carried alongside a quantity
-that describes its provenance, processing, or calibration state — not its
-physical identity. Aspects are orthogonal to kinds: two values with the
-same kind can differ in aspects, and vice versa.
+An *aspect* qualifies a quantity on terms its kind cannot express: two
+dose equivalents — same dimension, same unit, same kind — may still be
+weighted per different standards, and their sum conforms to neither.
+Aspects gate combination below the kind layer. (The flat string-set
+model that previously occupied this package was removed in v2.2.0; an
+unkeyed set cannot distinguish *conflict* from *absence*, which is the
+defect the aspect stratum exists to fix.)
 
 ```python
-from ucon.aspects import (
-    AspectSet,
-    AspectRule,
-    AspectJoinPolicy,
-    join_aspects,
+from ucon import (
+    Aspect,
+    AspectError,
+    AspectRefused,
+    AspectNotApplicable,
 )
+from ucon.aspects import AspectForest, MultPolicy
 ```
 
-### AspectSet
+### Aspect
 
-An immutable set of aspect names. `AspectSet` is a `frozenset` subclass
-with a variadic constructor for ergonomic construction:
+A frozen tree node, peer of `Kind`. The root of a tree *is* the family;
+subtrees group related positions (standards bodies, procedures) under
+it.
 
 ```python
-# Variadic (primary form)
-AspectSet("calibrated", "ICRP103")
+from ucon import Aspect
 
-# From an existing collection
-AspectSet({"calibrated", "ICRP103"})
-AspectSet(some_frozenset)
-
-# Empty
-AspectSet()
-
-# Single string is one aspect, not iterated as characters
-AspectSet("calibrated") == frozenset({"calibrated"})  # True
+family  = Aspect("weighting_standard",
+                 applies_to=frozenset({"dose_equivalent"}))
+icrp60  = Aspect("icrp60",  parent=family)
+icrp103 = Aspect("icrp103", parent=family)
 ```
 
-`AspectSet` is fully interchangeable with plain `frozenset[str]` at every
-internal surface. Set algebra (`&`, `|`, `-`, `^`) returns plain `frozenset`
-instances.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | str | required | Unique aspect name |
+| `parent` | Aspect \| None | `None` | Tree edge; `None` marks a family root |
+| `join_policy` | JoinPolicy | `REFUSE` | Consulted when this node is the LCA of a join (kinds default to `LCA`; aspects default to `REFUSE`) |
+| `applies_to` | frozenset[str] | `frozenset()` | **Root-only.** Kind names the family may attach to; empty = unrestricted, `{"*"}` = wildcard |
+| `multiplication_policy` | MultPolicy | `CARRY` | **Root-only.** How partial presence resolves under `×`/`÷` |
 
-### AspectJoinPolicy
+### `Number.aspects`
 
-Enum controlling how aspect sets combine when kinds join at the lattice
-(addition path):
-
-| Member | String value | Behaviour |
-|--------|--------------|-----------|
-| `AspectJoinPolicy.INTERSECT` | `"intersect"` | Keep only aspects present on **both** sides (default) |
-| `AspectJoinPolicy.UNION` | `"union"` | Keep every aspect from **either** side |
-
-### `join_aspects(a, b, policy=INTERSECT)`
-
-Pure function combining two aspect sets under the given policy. Does not
-consult a kind lattice; callers compose with `KindLattice.join` explicitly.
+`Number` carries an additive `aspects: frozenset[Aspect]` (default
+empty). `applies_to` is enforced at construction — the aspect layer's
+one sanctioned kind-read — so a false claim refuses at the moment it is
+made:
 
 ```python
-from ucon.aspects import join_aspects, AspectJoinPolicy
+from ucon import Number, units
 
-# Default: INTERSECT
-join_aspects(
-    frozenset({"signal_summary", "calibrated"}),
-    frozenset({"signal_summary"}),
-)
-# frozenset({"signal_summary"})
+dose = Number(2.0, units.gray, kind=dose_eq, aspects=[icrp103])
+repr(dose)   # '<2.0 Gy [dose_equivalent] #icrp103>'
 
-# Explicit UNION
-join_aspects(
-    frozenset({"signal_summary", "calibrated"}),
-    frozenset({"signal_summary"}),
-    policy=AspectJoinPolicy.UNION,
-)
-# frozenset({"signal_summary", "calibrated"})
+Number(1.5, units.gray, kind=absorbed, aspects=[icrp103])
+# AspectNotApplicable — weighting standards do not apply to absorbed dose
 ```
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `a`, `b` | AspectSet | required | Aspect sets to combine |
-| `policy` | AspectJoinPolicy | `INTERSECT` | Combination policy |
+### Arithmetic Resolution
 
-Raises `ValueError` if `policy` is not a recognised `AspectJoinPolicy`.
+Resolution is **family-wise**: both operands' aspects group by family
+root, and each family resolves independently. Cross-family comparison
+never happens.
+
+| Configuration | `+` / `−` | `×` / `÷` |
+|---------------|-----------|-----------|
+| Equal positions | carry | carry |
+| Differing positions | join at LCA under the ancestor's `join_policy` (`refuse` raises `AspectRefused`) | same |
+| Partial (one side silent) | strict: `AspectRefused`; permissive: inherit + warning | per the family's `multiplication_policy` (`carry` threads the present positions onto the product) |
+
+There is no `drop`: no resolution path silently discards a position.
+The carry rule survives kind degradation — a weighting standard rides
+`dose × time` even when the product's kind degrades — which is what
+keeps refusals alive through round trips:
+
+```python
+a = Number(2.0, units.gray, kind=dose_eq, aspects=[icrp103])
+b = Number(3.0, units.gray, kind=dose_eq, aspects=[icrp60])
+
+a + b                       # AspectRefused — same kind, different standard
+(a * t) / t                 # <2.0 Gy #icrp103> — carried and restored
+```
+
+Single-operand operations (`.to()`, scalar `*`/`/`, `**`, `simplify()`,
+`to_base()`, `Ratio.evaluate()`, `UnitSystem.adopt()`, `Bridge.apply()`)
+thread aspects unchanged.
+
+The resolvers are importable as pure functions —
+`resolve_add_aspects(left, right, *, strict)` and
+`resolve_mul_aspects(left, right)` via `ucon.aspects` — reading nothing
+but their operands and the strict bit.
+
+### AspectForest
+
+Declaration-time container: validates a set of aspect trees (passing
+leaves is enough — construction closes over parents), groups them by
+family, and answers `lca`/`join` queries. Each family runs on a private,
+mirrored kind-lattice engine, so join semantics are the same vetted code
+kinds use.
+
+```python
+from ucon.aspects import AspectForest
+
+forest = AspectForest([icrp60, icrp103])
+forest.families()                  # (weighting_standard,)
+forest.join(icrp60, icrp103)       # AspectRefused
+```
+
+### Exceptions
+
+```python
+from ucon import AspectError, AspectRefused, AspectNotApplicable
+```
+
+| Exception | When raised |
+|-----------|-------------|
+| `AspectError` | Base class; structural failures (duplicate names, orphan parents, root-only violations) |
+| `AspectRefused` | Two positions cannot be reconciled — carries `family`, `left`, `right`, `policy`; a `None` side marks the partial case |
+| `AspectNotApplicable` | A restricted family attached to the wrong kind (or an unkinded Number) — carries `family`, `kind` |
+
+No Kind-named exception ever surfaces from an aspect operation: engine
+errors are rewrapped as `AspectError` with the original chained as
+`__cause__`.
+
+### TOML
+
+Aspects are authored in `[[aspects]]` sections and loaded with
+`parse_aspects_payload` / `load_aspects_file` (via `ucon.parsing`); see
+[TOML Loaders](#toml-loaders-for-kinds-formulas) below and the
+[Serialization Format](serialization-format.md) reference. There are no
+builtin aspects: core ships mechanism, domains ship vocabulary.
 
 ---
 
 ## TOML Loaders for Kinds & Formulas
 
-New in v1.9.0. Kinds and formulas can be authored in TOML and loaded into
-a `KindLattice` and `FormulaRegistry`. The loaders are **independent of**
-the `ConversionGraph` TOML schema documented in
-[Serialization Format](serialization-format.md) — they read the `[[kinds]]`
-and `[[formulas]]` sections from any TOML file, and the two sections can
-share a file.
+Kinds, formulas, and aspects can be authored in TOML and loaded into a
+`KindLattice`, `FormulaRegistry`, and `AspectForest`. The loaders are
+**independent of** the `ConversionGraph` TOML schema documented in
+[Serialization Format](serialization-format.md) — they read the
+`[[kinds]]`, `[[formulas]]`, and `[[aspects]]` sections from any TOML
+file, and the sections can share a file.
 
 ```python
 from ucon.parsing import (
@@ -1811,6 +1847,8 @@ from ucon.parsing import (
     load_kinds_file,
     parse_formulas_payload,
     load_formulas_file,
+    parse_aspects_payload,
+    load_aspects_file,
 )
 ```
 
@@ -1851,9 +1889,6 @@ notes = "w_R per ICRP 103."
 [formulas.inputs]
 D = { kind = "absorbed_dose" }
 w_R = { kind = "radiation_weighting_factor" }
-
-[formulas.aspect_rules]
-w_R = "consume"
 ```
 
 | Key | Type | Required | Description |
@@ -1864,17 +1899,17 @@ w_R = "consume"
 | `inputs` | table | yes | Map of input names to `{ kind = "..." }` |
 | `commutative` | bool | no | Defaults to `true` |
 | `generalizes` | bool | no | Defaults to `false` |
-| `aspect_rules` | table | no | Map of binding names to `"consume"` or `"carry"` (keys must match `inputs`) |
 | `notes` | string | no | Free-form notes |
 
 ### Loading
 
 ```python
 from pathlib import Path
-from ucon.parsing import load_kinds_file, load_formulas_file
+from ucon.parsing import load_aspects_file, load_formulas_file, load_kinds_file
 
 lat = load_kinds_file(Path("radiation.ucon.toml"))
 reg = load_formulas_file(Path("radiation.ucon.toml"), lattice=lat)
+forest = load_aspects_file(Path("radiation.ucon.toml"))
 
 reg.get("radiation_weighting").output_kind.name  # "equivalent_dose"
 ```

--- a/docs/reference/modules/aspects.md
+++ b/docs/reference/modules/aspects.md
@@ -1,11 +1,13 @@
 # ucon.aspects
 
-Aspect data types and the pure join operation. An *aspect* is a covariant
-tag carried alongside a quantity describing its provenance, processing, or
-calibration state — orthogonal to kinds and dimensions.
+Aspects: the discriminator that gates combination below the kind layer.
+An *aspect* qualifies a quantity on terms its kind cannot express — the
+weighting standard behind a dose equivalent, the dry/wet basis of a
+mass fraction. Aspects are tree nodes grouped by family (the tree's
+root); resolution is family-wise.
 
 See [API › Aspects](../api.md#aspects) for usage and the
-[Kind-of-Quantity Problem](../../architecture/kind-of-quantity.md#aspect-propagation)
+[Kind-of-Quantity Problem](../../architecture/kind-of-quantity.md#the-aspect-stratum)
 for the conceptual framing.
 
 ::: ucon.aspects

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -21,7 +21,7 @@ For a curated overview with examples, see the [API Reference](../api.md).
 
 - **[ucon.kinds](kinds.md)** --- Kind, KindLattice, JoinPolicy
 - **[ucon.formulas](formulas.md)** --- KindFormula, FormulaRegistry, tiered lookup
-- **[ucon.aspects](aspects.md)** --- AspectSet, AspectRule, AspectJoinPolicy
+- **[ucon.aspects](aspects.md)** --- Aspect, AspectForest, family-wise resolution
 
 ## Integrations
 

--- a/docs/reference/serialization-format.md
+++ b/docs/reference/serialization-format.md
@@ -52,6 +52,7 @@ File metadata.
 name = "my-graph"
 format_version = "1.3"
 loaded_packages = ["si", "cgs"]   # optional
+namespace = "my-graph"            # optional
 ```
 
 | Key | Type | Required | Description |
@@ -59,6 +60,7 @@ loaded_packages = ["si", "cgs"]   # optional
 | `name` | string | yes | Package name (defaults to filename stem on export) |
 | `format_version` | string | yes | Schema version; current is `"1.2"` |
 | `loaded_packages` | array of strings | no | Names of packages baked into this graph |
+| `namespace` | string | no | Qualifies every unprefixed kind and aspect name (and kind-reference) in the file as `namespace:name` at load (v2.2.0). `@name` escapes to root; explicit `pkg:name` spellings pass through. The key is consumed by the rewrite, so the transformation is idempotent |
 
 ---
 
@@ -412,6 +414,36 @@ aliases = ["KE"]
 
 Kinds are loaded into `graph._kind_lattice` on import. Constants can reference
 kinds by name via the `kind` key.
+
+---
+
+## `[[aspects]]`
+
+Aspect declarations for the graph's aspect forest (v2.2.0).
+
+```toml
+[[aspects]]
+name = "weighting_standard"
+applies_to = ["dose_equivalent"]   # root-only
+join_policy = "refuse"             # default for aspects
+
+[[aspects]]
+name = "icrp103"
+parent = "weighting_standard"
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | string | yes | Canonical aspect name |
+| `parent` | string | no | Name of another entry (declaration order is free); absent marks a family root |
+| `join_policy` | string | no | `"refuse"` (default) or `"lca"` |
+| `applies_to` | array of strings | no | **Root-only.** Kind names the family attaches to; `["*"]` = wildcard |
+| `multiplication_policy` | string | no | **Root-only.** `"carry"` (default) |
+
+Aspects are loaded into `graph._aspect_forest` on import and re-emitted
+(defaults omitted, parents before children) on export. Root-only keys on
+a child entry are a load-time `AspectError`. The comprehensive catalog
+declares no aspects: core ships mechanism, domains ship vocabulary.
 
 ---
 

--- a/docs/reference/units-and-dimensions.md
+++ b/docs/reference/units-and-dimensions.md
@@ -183,6 +183,12 @@ These are the fundamental SI base dimensions.
 
 These share a zero-vector but are semantically distinct.
 
+!!! warning "Deprecated"
+    Pseudo-dimensions are deprecated as of v2.2.0 and will be removed in
+    3.0.0 (`Dimension.pseudo(...)` emits `PendingDeprecationWarning`).
+    The units below remain available; the migration path for semantic
+    isolation is a `Kind` over the dimensionless dimension.
+
 ### Angle
 
 | Unit | Shorthand | Aliases | Scalable |


### PR DESCRIPTION
Pre-tag housekeeping so the `2.2.0` tag is self-describing: the release notes live under their own header, and the external documentation describes the surface that actually ships.

## CHANGELOG

- `Unreleased` → `[2.2.0] - 2026-09-12`, fresh empty `Unreleased` above it, comparison link added.
- One accuracy fix: the pre-release entry saying the flat aspect model "will be removed" now reads past-tense — the Removed section in the same release did it.

## External docs brought current

- **`reference/api.md`** — the Aspects section rewritten from the removed flat model (`AspectSet` / `AspectRule` / `AspectJoinPolicy` / `join_aspects`) to the v2.2.0 stratum: `Aspect` trees and families, `Number.aspects`, family-wise resolution table, the carry rule, `AspectForest`, the exception surface, and the kinds-only `FormulaRegistry.apply` (3-tuple). `[[aspects]]` joins the TOML-loader schemas; `aspect_rules` is gone from the formula schema.
- **`architecture/kind-of-quantity.md`** — "Aspect Propagation" (CONSUME/CARRY, INTERSECT/UNION) replaced by "The Aspect Stratum" (family-wise resolution, carry rule, attachment); pseudo-dimensions (Solution 1) carry a deprecation admonition pointing at kinds; status sections updated to v2.2.0 reality.
- **`reference/serialization-format.md`** — new `[[aspects]]` section; `namespace` key documented under `[package]`.
- **`reference/units-and-dimensions.md`** — deprecation admonition on the pseudo-dimension catalog.
- **`reference/modules/{aspects,index}.md`** — module blurbs updated.

`make docs` builds clean with no broken links; no stale flat-model symbol remains anywhere under `docs/` outside internal design records.
