### PR TITLE
advance the ucon-tools docs submodule to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **ucon-tools docs submodule advanced to v0.9.0.** The
+  `docs/external/ucon-tools` pin had been frozen at 0.4.5rc1 while the
+  MCP-server guide and tool reference it serves into the docs site were
+  rewritten upstream; the published pages now describe the consolidated
+  discover/define/system tool surface.
+
 ## [2.2.0] - 2026-09-12
 
 ### Removed


### PR DESCRIPTION
The `docs/external/ucon-tools` submodule was pinned at 0.4.5rc1 (April) while ucon-tools moved to v0.9.0 — whose #41 rewrote the exact pages ucon's mkdocs nav serves (`guides/mcp-server/`, `reference/mcp-tools.md`). This advances the pin to current ucon-tools main (f213a34) so the published docs site describes the tool surface that actually ships. `mkdocs build` is clean against the new pin; all nav-referenced files present.